### PR TITLE
Updating copyrights and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-   Copyright 2014 the Java Client for Google Maps Services Authors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/DistanceMatrixApi.java
+++ b/src/main/java/com/google/maps/DistanceMatrixApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/DistanceMatrixApiRequest.java
+++ b/src/main/java/com/google/maps/DistanceMatrixApiRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/ElevationApi.java
+++ b/src/main/java/com/google/maps/ElevationApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/GeocodingApi.java
+++ b/src/main/java/com/google/maps/GeocodingApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/GeocodingApiRequest.java
+++ b/src/main/java/com/google/maps/GeocodingApiRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/PendingResult.java
+++ b/src/main/java/com/google/maps/PendingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/PendingResultBase.java
+++ b/src/main/java/com/google/maps/PendingResultBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/ApiException.java
+++ b/src/main/java/com/google/maps/errors/ApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/InvalidRequestException.java
+++ b/src/main/java/com/google/maps/errors/InvalidRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/MaxElementsExceededException.java
+++ b/src/main/java/com/google/maps/errors/MaxElementsExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/OverQueryLimitException.java
+++ b/src/main/java/com/google/maps/errors/OverQueryLimitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/RequestDeniedException.java
+++ b/src/main/java/com/google/maps/errors/RequestDeniedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/UnknownErrorException.java
+++ b/src/main/java/com/google/maps/errors/UnknownErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/errors/ZeroResultsException.java
+++ b/src/main/java/com/google/maps/errors/ZeroResultsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/AddressComponentTypeAdapter.java
+++ b/src/main/java/com/google/maps/internal/AddressComponentTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/AddressTypeAdapter.java
+++ b/src/main/java/com/google/maps/internal/AddressTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/ApiResponse.java
+++ b/src/main/java/com/google/maps/internal/ApiResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/DateTimeAdapter.java
+++ b/src/main/java/com/google/maps/internal/DateTimeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/DistanceAdapter.java
+++ b/src/main/java/com/google/maps/internal/DistanceAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/DurationAdapter.java
+++ b/src/main/java/com/google/maps/internal/DurationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/ExceptionResult.java
+++ b/src/main/java/com/google/maps/internal/ExceptionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/PolylineEncoding.java
+++ b/src/main/java/com/google/maps/internal/PolylineEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/StringJoin.java
+++ b/src/main/java/com/google/maps/internal/StringJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/TravelModeAdapter.java
+++ b/src/main/java/com/google/maps/internal/TravelModeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/internal/UrlSigner.java
+++ b/src/main/java/com/google/maps/internal/UrlSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/AddressComponent.java
+++ b/src/main/java/com/google/maps/model/AddressComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/Bounds.java
+++ b/src/main/java/com/google/maps/model/Bounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DirectionsRoute.java
+++ b/src/main/java/com/google/maps/model/DirectionsRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/Distance.java
+++ b/src/main/java/com/google/maps/model/Distance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DistanceMatrix.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/DistanceMatrixRow.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/Duration.java
+++ b/src/main/java/com/google/maps/model/Duration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/ElevationResult.java
+++ b/src/main/java/com/google/maps/model/ElevationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/EncodedPolyline.java
+++ b/src/main/java/com/google/maps/model/EncodedPolyline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/GeocodingResult.java
+++ b/src/main/java/com/google/maps/model/GeocodingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/Geometry.java
+++ b/src/main/java/com/google/maps/model/Geometry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/LocationType.java
+++ b/src/main/java/com/google/maps/model/LocationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/TravelMode.java
+++ b/src/main/java/com/google/maps/model/TravelMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/main/java/com/google/maps/model/Unit.java
+++ b/src/main/java/com/google/maps/model/Unit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/AuthenticatedTest.java
+++ b/src/test/java/com/google/maps/AuthenticatedTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.google.maps;
 
 import org.junit.Ignore;

--- a/src/test/java/com/google/maps/DirectionsApiTest.java
+++ b/src/test/java/com/google/maps/DirectionsApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/DistanceMatrixApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/DistanceMatrixApiIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/DistanceMatrixApiTest.java
+++ b/src/test/java/com/google/maps/DistanceMatrixApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/ElevationApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/ElevationApiIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/ElevationApiTest.java
+++ b/src/test/java/com/google/maps/ElevationApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/GeocodingApiTest.java
+++ b/src/test/java/com/google/maps/GeocodingApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/LargeTests.java
+++ b/src/test/java/com/google/maps/LargeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/MediumTests.java
+++ b/src/test/java/com/google/maps/MediumTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/SmallTests.java
+++ b/src/test/java/com/google/maps/SmallTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/TimeZoneApiTest.java
+++ b/src/test/java/com/google/maps/TimeZoneApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/internal/PolylineEncodingTest.java
+++ b/src/test/java/com/google/maps/internal/PolylineEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
+++ b/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.google.maps.internal;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/maps/internal/UrlSignerTest.java
+++ b/src/test/java/com/google/maps/internal/UrlSignerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/src/test/java/com/google/maps/model/LatLngAssert.java
+++ b/src/test/java/com/google/maps/model/LatLngAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Java Client for Google Maps Services Authors. All Rights Reserved.
+ * Copyright 2014 Google Inc. All rights reserved.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this


### PR DESCRIPTION
Removed first 14 lines of license.
Set (c) Google.
Added two headers that were previously blank.
