### PR TITLE
Don't throw exceptions when the server returns something we're not expecting.

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -106,5 +106,10 @@ public class DirectionsApi {
     public String toString() {
       return restriction;
     }
+
+    @Override
+    public String toUrlValue() {
+      return restriction;
+    }
   }
 }

--- a/src/main/java/com/google/maps/GeocodingApi.java
+++ b/src/main/java/com/google/maps/GeocodingApi.java
@@ -105,6 +105,11 @@ public class GeocodingApi {
 
     @Override
     public String toString() {
+      return toUrlValue();
+    }
+
+    @Override
+    public String toUrlValue() {
       return join(':', component, value);
     }
 

--- a/src/main/java/com/google/maps/internal/AddressComponentTypeAdapter.java
+++ b/src/main/java/com/google/maps/internal/AddressComponentTypeAdapter.java
@@ -51,7 +51,7 @@ public class AddressComponentTypeAdapter extends TypeAdapter<AddressComponentTyp
    */
   @Override
   public void write(JsonWriter writer, AddressComponentType value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/internal/AddressTypeAdapter.java
+++ b/src/main/java/com/google/maps/internal/AddressTypeAdapter.java
@@ -34,7 +34,7 @@ public class AddressTypeAdapter extends TypeAdapter<AddressType> {
 
   /**
    * Read a address component type from a Geocoding API result and convert it to a
-   * {@link AddressComponentType}.
+   * {@link com.google.maps.model.AddressComponentType}.
    */
   @Override
   public AddressType read(JsonReader reader) throws IOException {
@@ -51,7 +51,7 @@ public class AddressTypeAdapter extends TypeAdapter<AddressType> {
    */
   @Override
   public void write(JsonWriter writer, AddressType value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/internal/DateTimeAdapter.java
+++ b/src/main/java/com/google/maps/internal/DateTimeAdapter.java
@@ -79,7 +79,7 @@ public class DateTimeAdapter extends TypeAdapter<DateTime> {
    */
   @Override
   public void write(JsonWriter writer, DateTime value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/internal/DistanceAdapter.java
+++ b/src/main/java/com/google/maps/internal/DistanceAdapter.java
@@ -72,7 +72,7 @@ public class DistanceAdapter extends TypeAdapter<Distance> {
    */
   @Override
   public void write(JsonWriter writer, Distance value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/internal/DurationAdapter.java
+++ b/src/main/java/com/google/maps/internal/DurationAdapter.java
@@ -72,7 +72,7 @@ public class DurationAdapter extends TypeAdapter<Duration> {
    */
   @Override
   public void write(JsonWriter writer, Duration value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/internal/StringJoin.java
+++ b/src/main/java/com/google/maps/internal/StringJoin.java
@@ -25,6 +25,10 @@ public class StringJoin {
    * be string joinable.
    */
   public interface UrlValue {
+      /**
+       * @return the object, represented as a URL value (not URL encoded).
+       */
+      String toUrlValue();
   }
 
   private StringJoin() {

--- a/src/main/java/com/google/maps/internal/TravelModeAdapter.java
+++ b/src/main/java/com/google/maps/internal/TravelModeAdapter.java
@@ -50,7 +50,7 @@ public class TravelModeAdapter extends TypeAdapter<TravelMode> {
    */
   @Override
   public void write(JsonWriter writer, TravelMode value) throws IOException {
-    throw new RuntimeException("Unimplemented method");
+    throw new UnsupportedOperationException("Unimplemented method");
   }
 
 }

--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -15,6 +15,9 @@
 
 package com.google.maps.model;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * The Adress Component types. Please see
  * <a href="https://developers.google.com/maps/documentation/geocoding/#Types">Address Component
@@ -207,8 +210,15 @@ public enum AddressComponentType {
   /**
    * {@code TRANSIT_STATION} indicates the location of a transit station.
    */
-  TRANSIT_STATION("transit_station");
+  TRANSIT_STATION("transit_station"),
 
+  /**
+   * Indicates an unknown address component type returned by the server. The Java Client for Google
+   * Maps Services should be updated to support the new value.
+   */
+  UNKNOWN("unknown");
+
+  private static Logger log = Logger.getLogger(AddressComponentType.class.getName());
 
   private String addressComponentType;
 
@@ -297,7 +307,8 @@ public enum AddressComponentType {
     } else if (addressComponentType.equalsIgnoreCase(SUBLOCALITY_LEVEL_5.toString())) {
       return SUBLOCALITY_LEVEL_5;
     } else {
-      throw new RuntimeException("Unknown address component type '" + addressComponentType + "'");
+      log.log(Level.WARNING, "Unknown address component type '%s'", addressComponentType);
+      return UNKNOWN;
     }
   }
 }

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -17,6 +17,9 @@ package com.google.maps.model;
 
 import com.google.maps.internal.StringJoin.UrlValue;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * The Adress types. Please see
  * <a href="https://developers.google.com/maps/documentation/geocoding/#Types">Address
@@ -177,7 +180,15 @@ public enum AddressType implements UrlValue {
   /**
    * {@code TRANSIT_STATION} indicates the location of a transit station.
    */
-  TRANSIT_STATION("transit_station");
+  TRANSIT_STATION("transit_station"),
+
+  /**
+   * Indicates an unknown address type returned by the server. The Java Client for Google Maps
+   * Services should be updated to support the new value.
+   */
+  UNKNOWN("unknown");
+
+  private static Logger log = Logger.getLogger(AddressType.class.getName());
 
   private String addressType;
 
@@ -187,6 +198,14 @@ public enum AddressType implements UrlValue {
 
   @Override
   public String toString() {
+    return addressType;
+  }
+
+  @Override
+  public String toUrlValue() {
+    if (this == UNKNOWN) {
+      throw new UnsupportedOperationException("Shouldn't use AddressType.UNKNOWN in a request.");
+    }
     return addressType;
   }
 
@@ -254,7 +273,8 @@ public enum AddressType implements UrlValue {
     } else if (addressType.equalsIgnoreCase(SUBLOCALITY_LEVEL_5.toString())) {
       return SUBLOCALITY_LEVEL_5;
     } else {
-      throw new RuntimeException("Unknown address type '" + addressType + "'");
+      log.log(Level.WARNING, "Unknown address type '%s'", addressType);
+      return UNKNOWN;
     }
   }
 }

--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -44,6 +44,11 @@ public class LatLng implements UrlValue {
 
   @Override
   public String toString() {
+    return toUrlValue();
+  }
+
+  @Override
+  public String toUrlValue() {
     // Enforce Locale to English for double to string conversion
     return String.format(Locale.ENGLISH, "%f,%f", lat, lng);
   }

--- a/src/main/java/com/google/maps/model/LocationType.java
+++ b/src/main/java/com/google/maps/model/LocationType.java
@@ -17,6 +17,9 @@ package com.google.maps.model;
 
 import com.google.maps.internal.StringJoin.UrlValue;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Location types for a reverse geocoding request. Please see
  * <a href="https://developers.google.com/maps/documentation/geocoding/#ReverseGeocoding">for
@@ -27,7 +30,7 @@ public enum LocationType implements UrlValue {
    * {@code ROOFTOP} restricts the results to addresses for which we have location information
    * accurate down to street address precision.
    */
-  ROOFTOP("ROOFTOP"),
+  ROOFTOP,
 
   /**
    * {@code RANGE_INTERPOLATED} restricts the results to those that reflect an approximation
@@ -35,23 +38,34 @@ public enum LocationType implements UrlValue {
    * interpolated range generally indicates that rooftop geocodes are unavailable for a street
    * address.
    */
-  RANGE_INTERPOLATED("RANGE_INTERPOLATED"),
+  RANGE_INTERPOLATED,
 
   /**
    * {@code GEOMETRIC_CENTER} restricts the results to geometric centers of a location such as a
    * polyline (for example, a street) or polygon (region).
    */
-  GEOMETRIC_CENTER("GEOMETRIC_CENTER"),
+  GEOMETRIC_CENTER,
 
   /**
    * {@code APPROXIMATE} restricts the results to those that are characterized as approximate.
    */
-  APPROXIMATE("APPROXIMATE");
+  APPROXIMATE,
 
-  private String locationType;
+  /**
+   * Indicates an unknown location type returned by the server. The Java Client for Google Maps
+   * Services should be updated to support the new value.
+   */
+  UNKNOWN;
 
-  LocationType(String locationType) {
-    this.locationType = locationType;
+
+  private static Logger log = Logger.getLogger(LocationType.class.getName());
+
+  @Override
+  public String toUrlValue() {
+    if (this == UNKNOWN) {
+      throw new UnsupportedOperationException("Shouldn't use LocationType.UNKNOWN in a request.");
+    }
+    return toString();
   }
 
   public LocationType lookup(String locationType) {
@@ -64,7 +78,8 @@ public enum LocationType implements UrlValue {
     } else if (locationType.equalsIgnoreCase(APPROXIMATE.toString())) {
       return APPROXIMATE;
     } else {
-      throw new RuntimeException("Unknown location type '" + locationType + "'");
+      log.log(Level.WARNING, "Unknown location type '%s'", locationType);
+      return UNKNOWN;
     }
   }
 }

--- a/src/main/java/com/google/maps/model/TravelMode.java
+++ b/src/main/java/com/google/maps/model/TravelMode.java
@@ -17,6 +17,9 @@ package com.google.maps.model;
 
 import com.google.maps.internal.StringJoin.UrlValue;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * You may specify the transportation mode to use for calulating directions. Directions are
  * calculating as driving directions by default.
@@ -27,7 +30,15 @@ import com.google.maps.internal.StringJoin.UrlValue;
  * .com/maps/documentation/distancematrix/#RequestParameters">Distance Matrix API travel modes</a>
  */
 public enum TravelMode implements UrlValue {
-  DRIVING("driving"), WALKING("walking"), BICYCLING("bicycling"), TRANSIT("transit");
+  DRIVING("driving"), WALKING("walking"), BICYCLING("bicycling"), TRANSIT("transit"),
+
+  /**
+   * Indicates an unknown travel mode returned by the server. The Java Client for Google Maps
+   * Services should be updated to support the new value.
+   */
+  UNKNOWN("unknown");
+
+  private static Logger log = Logger.getLogger(TravelMode.class.getName());
 
   private final String mode;
 
@@ -50,7 +61,16 @@ public enum TravelMode implements UrlValue {
     } else if (travelMode.equalsIgnoreCase(TRANSIT.toString())) {
       return TRANSIT;
     } else {
-      throw new RuntimeException("Unknown Travel Mode '" + travelMode + "'");
+      log.log(Level.WARNING, "Unknown Travel Mode '%s'", travelMode);
+      return UNKNOWN;
     }
+  }
+
+  @Override
+  public String toUrlValue() {
+    if (this == UNKNOWN) {
+      throw new UnsupportedOperationException("Shouldn't use TravelMode.UNKNOWN in a request.");
+    }
+    return mode;
   }
 }

--- a/src/main/java/com/google/maps/model/Unit.java
+++ b/src/main/java/com/google/maps/model/Unit.java
@@ -33,4 +33,10 @@ public enum Unit implements UrlValue {
   public String toString() {
     return type;
   }
+
+
+  @Override
+  public String toUrlValue() {
+    return type;
+  }
 }


### PR DESCRIPTION
Some of our enum lookups would start failing when the server has been updated but the client hadn't.

Change UrlValue interface to be more explicit, so we can change behaviour depending on the context. toUrlValue is called only when constructing requests, so we can make sure people don't use the new "UNKNOWN" types in requests.

cleanup: throw UnsupportedOperationException in write() in the gson TypeAdapters.
