### PR TITLE
Response parsing and dependency on StandardCharsets class

### DIFF
--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -231,14 +231,11 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
   private byte[] getBytes(Response response) throws IOException {
     InputStream in = response.body().byteStream();
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-
     int bytesRead;
-    byte[] data = new byte[16384];
-
+    byte[] data = new byte[8192];
     while ((bytesRead = in.read(data, 0, data.length)) != -1) {
       buffer.write(data, 0, bytesRead);
     }
-
     buffer.flush();
     return buffer.toByteArray();
   }


### PR DESCRIPTION
Currently response parsing transitively depends on StandardCharsets class, that is not available on Android devices running on API lower than level 19, what makes using your library in Android applications impossible.
This patch eliminates this dependency. There is also an option to use Apache Commons IO, but in case of Android applications this is an extra ~180 kilobytes to a final application size.
