### PR TITLE
Adding support for maneuver in the directions api.

### DIFF
--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -44,6 +44,7 @@ public class DirectionsStep {
   /**
    * {@code distance} contains the distance covered by this step until the next step.
    */
+  @Deprecated
   public Distance distance;
 
   /**

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -47,6 +47,11 @@ public class DirectionsStep {
   public Distance distance;
 
   /**
+   * {@code maneuver} contains the maneuver required to move ahead. eg., turn-left
+   */
+  public String maneuver;
+
+  /**
    * {@code duration} contains the typical time required to perform the step, until the next step.
    */
   public Duration duration;


### PR DESCRIPTION

The directions API returns a useful element called maneuver which mentions the next action a traveler needs to take. 

This commit adds support to parse that. It was pretty simple since the system does parsing internally based on the field names. I just needed to add the file name.

```
"steps" : [
                ...
                     "html_instructions" : "Turn \u003cb\u003eright\u003c/b\u003e onto \u003cb\u003eWightman St\u003c/b\u003e",
                     "maneuver" : "turn-right",
                     "polyline" : {
                        "points" : "w`yuFf{yfNn@?X?X?X?zBClEGxCAj@A~BG"
                     },
                     "travel_mode" : "DRIVING"
                     ....
                  }
```

Thanks,
Pulkit
