### PR TITLE
Adds Proxy support to GeoApiContext

### DIFF
--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -54,15 +54,8 @@ public class GeoApiContext {
   private long errorTimeout = DEFAULT_BACKOFF_TIMEOUT_MILLIS;
 
   public GeoApiContext() {
-    this(null);
-  }
-
-  public GeoApiContext(Proxy proxy) {
     rateLimitExecutorService = new RateLimitExecutorService();
     client.setDispatcher(new Dispatcher(rateLimitExecutorService));
-    if(proxy != null) {
-      client.setProxy(proxy);
-    }
   }
 
   <T, R extends ApiResponse<T>> PendingResult<T> get(ApiConfig config, Class<? extends R> clazz,
@@ -231,6 +224,16 @@ public class GeoApiContext {
    */
   public GeoApiContext setQueryRateLimit(int maxQps, int minimumInterval) {
     rateLimitExecutorService.setQueriesPerSecond(maxQps, minimumInterval);
+    return this;
+  }
+
+  /**
+   * Sets the proxy for new connections.
+   *
+   * @param proxy The proxy to be used by the underlying HTTP client.
+   */
+  public GeoApiContext setProxy(Proxy proxy) {
+    client.setProxy(proxy == null ? Proxy.NO_PROXY : proxy);
     return this;
   }
 }

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -28,6 +28,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 
 import java.io.UnsupportedEncodingException;
+import java.net.Proxy;
 import java.net.URLEncoder;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -53,8 +54,15 @@ public class GeoApiContext {
   private long errorTimeout = DEFAULT_BACKOFF_TIMEOUT_MILLIS;
 
   public GeoApiContext() {
+    this(null);
+  }
+
+  public GeoApiContext(Proxy proxy) {
     rateLimitExecutorService = new RateLimitExecutorService();
     client.setDispatcher(new Dispatcher(rateLimitExecutorService));
+    if(proxy != null) {
+      client.setProxy(proxy);
+    }
   }
 
   <T, R extends ApiResponse<T>> PendingResult<T> get(ApiConfig config, Class<? extends R> clazz,


### PR DESCRIPTION
This pull request adds support for Proxy configuration.

It just sets the `Proxy` object on the underlying `OkHttpClient` when constructing `GeoApiContext` like so:

```java
GeoApiContext context = new GeoApiContext(new Proxy(Type.HTTP, new InetSocketAddress("host", 8000)));
```