### PR TITLE
Allow external overriding of base url for testing

### DIFF
--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -169,7 +169,7 @@ public class GeoApiContext {
    * Override the base URL of the API endpoint. Useful only for testing.
    * @param baseUrl  The URL to use, without a trailing slash, e.g. https://maps.googleapis.com
    */
-  GeoApiContext setBaseUrlForTesting(String baseUrl) {
+  public GeoApiContext setBaseUrlForTesting(String baseUrl) {
     baseUrlOverride = baseUrl;
     return this;
   }


### PR DESCRIPTION
People will want to mock requests / responses from outside of the core project.
Opening up the setBaseUrlForTesting method seems like the best way to allow the use of mock servers, like WireMock and such.