### PR TITLE
xFixing the precision issue

### DIFF
--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -50,6 +50,6 @@ public class LatLng implements UrlValue {
   @Override
   public String toUrlValue() {
     // Enforce Locale to English for double to string conversion
-    return String.format(Locale.ENGLISH, "%f,%f", lat, lng);
+    return String.format(Locale.ENGLISH, "%s,%s", lat, lng);
   }
 }


### PR DESCRIPTION
There is a loss of precision as %f will return only 6 digits after the decimal.
While the lat lng contains 7 digits after decimal. So while rounding them to 6 digits there is a loss of precision which in realtime is leading to a difference of 15 minutes.

@broady @domesticmouse please review.