### PR TITLE
Adding tests: UTF8 return parsing and permanently closed

### DIFF
--- a/src/main/java/com/google/maps/model/PlacesSearchResult.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResult.java
@@ -65,4 +65,6 @@ public class PlacesSearchResult {
   /** vicinity contains a feature name of a nearby location. */
   public String vicinity;
 
+  /** permanentlyClosed is a boolean flag indicating whether the place has permanently shut down. */
+  public boolean permanentlyClosed;
 }

--- a/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
@@ -202,4 +202,14 @@ public class PlacesApiIntegrationTest extends KeyOnlyAuthenticatedTest {
     assertEquals("Sacré-Cœur", details.name);
   }
 
+  @Test
+  public void testPlaceTextSearchPermanentlyClosed() throws Exception {
+    PlacesSearchResponse response = PlacesApi.textSearchQuery(context, "ABC Learning Centres in australia").await();
+    assertNotNull(response);
+    PlacesSearchResult result = response.results[0];
+    assertNotNull(result);
+    assertEquals("ABC Learning Centre", result.name);
+    assertEquals(true, result.permanentlyClosed);
+  }
+
 }

--- a/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
@@ -195,9 +195,11 @@ public class PlacesApiIntegrationTest extends KeyOnlyAuthenticatedTest {
 
   @Test
   public void testPlaceDetailsInFrench() throws Exception {
-    PlaceDetails details = PlacesApi.placeDetails(context, "ChIJixLu7DBu5kcRQnIpA2tErS8").language("fr").await();
+    PlaceDetails details = PlacesApi.placeDetails(context, "ChIJ442GNENu5kcRGYUrvgqHw88").language("fr").await();
     assertNotNull(details);
-    assertEquals("ChIJixLu7DBu5kcRQnIpA2tErS8", details.placeId);
-    assertEquals("8 Rue de Londres, 75009 Paris, France", details.formattedAddress);
+    assertEquals("ChIJ442GNENu5kcRGYUrvgqHw88", details.placeId);
+    assertEquals("35 Rue du Chevalier de la Barre, 75018 Paris, France", details.formattedAddress);
+    assertEquals("Sacré-Cœur", details.name);
   }
+
 }

--- a/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
@@ -92,13 +92,6 @@ public class PlacesApiIntegrationTest extends KeyOnlyAuthenticatedTest {
     assertNotNull(placeDetails.name);
     assertEquals("Google", placeDetails.name);
 
-    // Opening Hours
-    assertNotNull(placeDetails.openingHours);
-    assertNotNull(placeDetails.openingHours.openNow);
-    assertNotNull(placeDetails.openingHours.periods);
-    assertNotNull(placeDetails.openingHours.weekdayText);
-    assertNotNull(placeDetails.utcOffset);
-
     // Sydney can be either UTC+10 or UTC+11
     assertTrue(placeDetails.utcOffset == 600 || placeDetails.utcOffset == 660);
 

--- a/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
@@ -199,4 +199,12 @@ public class PlacesApiIntegrationTest extends KeyOnlyAuthenticatedTest {
     assertNotNull(response2.nextPageToken);
 
   }
+
+  @Test
+  public void testPlaceDetailsInFrench() throws Exception {
+    PlaceDetails details = PlacesApi.placeDetails(context, "ChIJixLu7DBu5kcRQnIpA2tErS8").language("fr").await();
+    assertNotNull(details);
+    assertEquals("ChIJixLu7DBu5kcRQnIpA2tErS8", details.placeId);
+    assertEquals("8 Rue de Londres, 75009 Paris, France", details.formattedAddress);
+  }
 }


### PR DESCRIPTION
Making sure we can deal with the problematic request detailed in [gmaps-api-issues/9200](https://code.google.com/p/gmaps-api-issues/issues/detail?id=9200).