### PR TITLE
Fix places autocomplete types parameter and introduced correct type enum

### DIFF
--- a/src/main/java/com/google/maps/PlaceAutocompleteRequest.java
+++ b/src/main/java/com/google/maps/PlaceAutocompleteRequest.java
@@ -24,7 +24,7 @@ import com.google.maps.internal.ApiResponse;
 import com.google.maps.model.AutocompletePrediction;
 import com.google.maps.model.ComponentFilter;
 import com.google.maps.model.LatLng;
-import com.google.maps.model.PlaceType;
+import com.google.maps.model.PlaceAutocompleteType;
 
 /**
  * A <a href="https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests">Place
@@ -77,8 +77,8 @@ public class PlaceAutocompleteRequest
   /**
    * type restricts the results to places matching the specified type.
    */
-  public PlaceAutocompleteRequest type(PlaceType type) {
-    return param("type", type);
+  public PlaceAutocompleteRequest type(PlaceAutocompleteType type) {
+    return param("types", type);
   }
 
   /**

--- a/src/main/java/com/google/maps/model/PlaceAutocompleteType.java
+++ b/src/main/java/com/google/maps/model/PlaceAutocompleteType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.google.maps.model;
+
+import com.google.maps.internal.StringJoin;
+
+/**
+ * PlaceAutocompleteType is used by the Places API to restrict the autocomplete results to places matching the specified
+ * type.
+ */
+public enum PlaceAutocompleteType implements StringJoin.UrlValue {
+    GEOCODE("geocode"),
+    ADDRESS("address"),
+    ESTABLISHMENT("establishment"),
+    REGIONS("(regions)"),
+    CITIES("(cities)");
+
+    PlaceAutocompleteType(final String placeType) {
+        this.placeType = placeType;
+    }
+
+    private String placeType;
+
+    @Override
+    public String toUrlValue() {
+        return placeType;
+    }
+
+    @Override
+    public String toString() {
+        return placeType;
+    }
+}

--- a/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/PlacesApiIntegrationTest.java
@@ -18,13 +18,15 @@ package com.google.maps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
-import com.google.maps.model.AddressType;
 import com.google.maps.model.AutocompletePrediction;
+import com.google.maps.model.ComponentFilter;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.Photo;
 import com.google.maps.model.PhotoResult;
+import com.google.maps.model.PlaceAutocompleteType;
 import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceIdScope;
 import com.google.maps.model.PlaceType;
@@ -309,6 +311,22 @@ public class PlacesApiIntegrationTest extends KeyOnlyAuthenticatedTest {
     assertNotNull(predictions);
     assertTrue(predictions.length > 0);
     assertTrue(predictions[0].description.startsWith("Sydney Town Hall"));
+  }
+
+  @Test
+  public void testPlaceAutocompleteWithType() throws Exception {
+    AutocompletePrediction[] predictions = PlacesApi.placeAutocomplete(context, "po")
+            .components(ComponentFilter.country("nz"))
+            .type(PlaceAutocompleteType.REGIONS)
+            .await();
+    assertNotNull(predictions);
+    assertTrue(predictions.length > 0);
+    for (int i = 0; i < predictions.length; i++) {
+      for (int j = 0; j < predictions[i].types.length; j++) {
+        assertFalse(predictions[i].types[j].equals("route"));
+        assertFalse(predictions[i].types[j].equals("establishment"));
+      }
+    }
   }
 
   @Test

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -28,6 +28,7 @@ import com.google.maps.model.LatLng;
 import com.google.maps.model.OpeningHours.Period;
 import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
 import com.google.maps.model.Photo;
+import com.google.maps.model.PlaceAutocompleteType;
 import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceDetails.Review.AspectRating.RatingType;
 import com.google.maps.model.PlaceIdScope;
@@ -38,6 +39,7 @@ import com.google.maps.model.PriceLevel;
 import com.google.maps.model.RankBy;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
+
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -656,7 +658,7 @@ public class PlacesApiTest {
         .offset(4)
         .location(location)
         .radius(5000)
-        .type(PlaceType.AIRPORT)
+        .type(PlaceAutocompleteType.ESTABLISHMENT)
         .components(ComponentFilter.country("AU"))
         .awaitIgnoreError();
 
@@ -666,7 +668,7 @@ public class PlacesApiTest {
     assertParamValue(Integer.toString(4), "offset", actualParams);
     assertParamValue(location.toUrlValue(), "location", actualParams);
     assertParamValue("5000", "radius", actualParams);
-    assertParamValue(PlaceType.AIRPORT.toString(), "type", actualParams);
+    assertParamValue(PlaceAutocompleteType.ESTABLISHMENT.toString(), "types", actualParams);
     assertParamValue(ComponentFilter.country("AU").toString(), "components", actualParams);
   }
 


### PR DESCRIPTION
Based on my understanding, the autocomplete for places is slightly different than the places search. In particular, it has a parameter name "types" that takes a restricted set of values.

https://developers.google.com/places/web-service/autocomplete

This PR adjusts the autocomplete to reflect this