### PR TITLE
Adding canonical literals for AddressComponentType

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -25,209 +25,225 @@ public enum AddressComponentType {
   /**
    * {@code STREET_ADDRESS} indicates a precise street address.
    */
-  STREET_ADDRESS,
+  STREET_ADDRESS("street_address"),
 
   /**
    * {@code ROUTE} indicates a named route (such as "US 101").
    */
-  ROUTE,
+  ROUTE("route"),
 
   /**
    * {@code INTERSECTION} indicates a major intersection, usually of two major roads.
    */
-  INTERSECTION,
+  INTERSECTION("intersection"),
 
   /**
    * {@code POLITICAL} indicates a political entity. Usually, this type indicates a polygon of some
    * civil administration.
    */
-  POLITICAL,
+  POLITICAL("political"),
 
   /**
    * {@code COUNTRY} indicates the national political entity, and is typically the highest order
    * type returned by the Geocoder.
    */
-  COUNTRY,
+  COUNTRY("country"),
 
   /**
    * {@code ADMINISTRATIVE_AREA_LEVEL_1} indicates a first-order civil entity below the country
    * level. Within the United States, these administrative levels are states. Not all nations
    * exhibit these administrative levels.
    */
-  ADMINISTRATIVE_AREA_LEVEL_1,
+  ADMINISTRATIVE_AREA_LEVEL_1("administrative_area_level_1"),
 
   /**
    * {@code ADMINISTRATIVE_AREA_LEVEL_2} indicates a second-order civil entity below the country
    * level. Within the United States, these administrative levels are counties. Not all nations
    * exhibit these administrative levels.
    */
-  ADMINISTRATIVE_AREA_LEVEL_2,
+  ADMINISTRATIVE_AREA_LEVEL_2("administrative_area_level_2"),
 
   /**
    * {@code ADMINISTRATIVE_AREA_LEVEL_3} indicates a third-order civil entity below the country
    * level. This type indicates a minor civil division. Not all nations exhibit these administrative
    * levels.
    */
-  ADMINISTRATIVE_AREA_LEVEL_3,
+  ADMINISTRATIVE_AREA_LEVEL_3("administrative_area_level_3"),
 
   /**
    * {@code ADMINISTRATIVE_AREA_LEVEL_4} indicates a fourth-order civil entity below the country
    * level. This type indicates a minor civil division. Not all nations exhibit these administrative
    * levels.
    */
-  ADMINISTRATIVE_AREA_LEVEL_4,
+  ADMINISTRATIVE_AREA_LEVEL_4("administrative_area_level_4"),
 
   /**
    * {@code ADMINISTRATIVE_AREA_LEVEL_5} indicates a fifth-order civil entity below the country
    * level. This type indicates a minor civil division. Not all nations exhibit these administrative
    * levels.
    */
-  ADMINISTRATIVE_AREA_LEVEL_5,
+  ADMINISTRATIVE_AREA_LEVEL_5("administrative_area_level_5"),
 
   /**
    * {@code COLLOQUIAL_AREA} indicates a commonly-used alternative name for the entity.
    */
-  COLLOQUIAL_AREA,
+  COLLOQUIAL_AREA("colloquial_area"),
 
   /**
    * {@code LOCALITY} indicates an incorporated city or town political entity.
    */
-  LOCALITY,
+  LOCALITY("locality"),
 
   /**
    * {@code SUBLOCALITY} indicates a first-order civil entity below a locality. For some locations
    * may receive one of the additional types: sublocality_level_1 to sublocality_level_5. Each
    * sublocality level is a civil entity. Larger numbers indicate a smaller geographic area.
    */
-  SUBLOCALITY,
-  SUBLOCALITY_LEVEL_1,
-  SUBLOCALITY_LEVEL_2,
-  SUBLOCALITY_LEVEL_3,
-  SUBLOCALITY_LEVEL_4,
-  SUBLOCALITY_LEVEL_5,
+  SUBLOCALITY("sublocality"),
+  SUBLOCALITY_LEVEL_1("sublocality_level_1"),
+  SUBLOCALITY_LEVEL_2("sublocality_level_2"),
+  SUBLOCALITY_LEVEL_3("sublocality_level_3"),
+  SUBLOCALITY_LEVEL_4("sublocality_level_4"),
+  SUBLOCALITY_LEVEL_5("sublocality_level_5"),
 
 
   /**
    * {@code NEIGHBORHOOD} indicates a named neighborhood.
    */
-  NEIGHBORHOOD,
+  NEIGHBORHOOD("neighborhood"),
 
   /**
    * {@code PREMISE} indicates a named location, usually a building or collection of buildings with
    * a common name.
    */
-  PREMISE,
+  PREMISE("premise"),
 
   /**
    * {@code SUBPREMISE} indicates a first-order entity below a named location, usually a singular
    * building within a collection of buildings with a common name
    */
-  SUBPREMISE,
+  SUBPREMISE("subpremise"),
 
   /**
    * {@code POSTAL_CODE} indicates a postal code as used to address postal mail within the country.
    */
-  POSTAL_CODE,
+  POSTAL_CODE("postal_code"),
 
   /**
    * {@code POSTAL_CODE_PREFIX} indicates a postal code prefix as used to address postal mail within
    * the country.
    */
-  POSTAL_CODE_PREFIX,
+  POSTAL_CODE_PREFIX("postal_code_prefix"),
 
   /**
    * {@code POSTAL_CODE_SUFFIX} indicates a postal code suffix as used to address postal mail within
    * the country.
    */
-  POSTAL_CODE_SUFFIX,
+  POSTAL_CODE_SUFFIX("postal_code_suffix"),
 
   /**
    * {@code NATURAL_FEATURE} indicates a prominent natural feature.
    */
-  NATURAL_FEATURE,
+  NATURAL_FEATURE("natural_feature"),
 
   /**
    * {@code AIRPORT} indicates an airport.
    */
-  AIRPORT,
+  AIRPORT("airport"),
 
   /**
    * {@code PARK} indicates a named park.
    */
-  PARK,
+  PARK("park"),
 
   /**
    * {@code POINT_OF_INTEREST} indicates a named point of interest. Typically, these "POI"s are
    * prominent local entities that don't easily fit in another category, such as "Empire State
    * Building" or "Statue of Liberty."
    */
-  POINT_OF_INTEREST,
+  POINT_OF_INTEREST("point_of_interest"),
 
   /**
    * {@code FLOOR} indicates the floor of a building address.
    */
-  FLOOR,
+  FLOOR("floor"),
 
   /**
    * {@code ESTABLISHMENT} typically indicates a place that has not yet been categorized.
    */
-  ESTABLISHMENT,
+  ESTABLISHMENT("establishment"),
 
   /**
    * {@code PARKING} indicates a parking lot or parking structure.
    */
-  PARKING,
+  PARKING("parking"),
 
   /**
    * {@code POST_BOX} indicates a specific postal box.
    */
-  POST_BOX,
+  POST_BOX("post_box"),
 
   /**
    * {@code POSTAL_TOWN} indicates a grouping of geographic areas, such as locality and sublocality,
    * used for mailing addresses in some countries.
    */
-  POSTAL_TOWN,
+  POSTAL_TOWN("postal_town"),
 
   /**
    * {@code ROOM} indicates the room of a building address.
    */
-  ROOM,
+  ROOM("room"),
 
   /**
    * {@code STREET_NUMBER} indicates the precise street number.
    */
-  STREET_NUMBER,
+  STREET_NUMBER("street_number"),
 
   /**
    * {@code BUS_STATION} indicates the location of a bus stop.
    */
-  BUS_STATION,
+  BUS_STATION("bus_station"),
 
   /**
    * {@code TRAIN_STATION} indicates the location of a train station.
    */
-  TRAIN_STATION,
+  TRAIN_STATION("train_station"),
 
   /**
    * {@code SUBWAY_STATION} indicates the location of a subway station.
    */
-  SUBWAY_STATION,
+  SUBWAY_STATION("subway_station"),
 
   /**
    * {@code TRANSIT_STATION} indicates the location of a transit station.
    */
-  TRANSIT_STATION,
+  TRANSIT_STATION("transit_station"),
 
   /**
    * {@code WARD} indicates a specific type of Japanese locality, to facilitate distinction between multiple locality components within a Japanese address.
    */
-  WARD,
+  WARD("ward"),
 
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.
    */
-  UNKNOWN
+  UNKNOWN("unknown");
+
+  private final String addressComponentType;
+
+  AddressComponentType(final String addressComponentType) {
+    this.addressComponentType = addressComponentType;
+  }
+
+  @Override
+  public String toString() {
+    return addressComponentType;
+  }
+
+  public String toCanonicalLiteral() {
+    return toString();
+  }
+
 }
 

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -234,6 +234,10 @@ public enum AddressType implements UrlValue {
     return addressType;
   }
 
+  public String toCanonicalLiteral() {
+    return toString();
+  }
+
   @Override
   public String toUrlValue() {
     if (this == UNKNOWN) {

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import static com.google.maps.internal.StringJoin.UrlValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -23,6 +24,9 @@ import com.google.maps.SmallTests;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Category(SmallTests.class)
 public class EnumsTest {
@@ -34,6 +38,129 @@ public class EnumsTest {
     assertCannotGetUrlValue(LocationType.UNKNOWN);
     assertCannotGetUrlValue(TravelMode.UNKNOWN);
 
+  }
+
+  @Test
+  public void testCanonicalLiteralsForAddressType() {
+    Map<AddressType, String> addressTypeToLiteralMap = new HashMap<AddressType, String>();
+    addressTypeToLiteralMap.put(AddressType.STREET_ADDRESS, "street_address");
+    addressTypeToLiteralMap.put(AddressType.ROUTE, "route");
+    addressTypeToLiteralMap.put(AddressType.INTERSECTION, "intersection");
+    addressTypeToLiteralMap.put(AddressType.POLITICAL, "political");
+    addressTypeToLiteralMap.put(AddressType.COUNTRY, "country");
+    addressTypeToLiteralMap.put(AddressType.ADMINISTRATIVE_AREA_LEVEL_1,
+                                "administrative_area_level_1");
+    addressTypeToLiteralMap.put(AddressType.ADMINISTRATIVE_AREA_LEVEL_2,
+                                "administrative_area_level_2");
+    addressTypeToLiteralMap.put(AddressType.ADMINISTRATIVE_AREA_LEVEL_3,
+                                "administrative_area_level_3");
+    addressTypeToLiteralMap.put(AddressType.ADMINISTRATIVE_AREA_LEVEL_4,
+                                "administrative_area_level_4");
+    addressTypeToLiteralMap.put(AddressType.ADMINISTRATIVE_AREA_LEVEL_5,
+                                "administrative_area_level_5");
+    addressTypeToLiteralMap.put(AddressType.COLLOQUIAL_AREA, "colloquial_area");
+    addressTypeToLiteralMap.put(AddressType.LOCALITY, "locality");
+    addressTypeToLiteralMap.put(AddressType.WARD, "ward");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY, "sublocality");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY_LEVEL_1, "sublocality_level_1");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY_LEVEL_2, "sublocality_level_2");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY_LEVEL_3, "sublocality_level_3");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY_LEVEL_4, "sublocality_level_4");
+    addressTypeToLiteralMap.put(AddressType.SUBLOCALITY_LEVEL_5, "sublocality_level_5");
+    addressTypeToLiteralMap.put(AddressType.NEIGHBORHOOD, "neighborhood");
+    addressTypeToLiteralMap.put(AddressType.PREMISE, "premise");
+    addressTypeToLiteralMap.put(AddressType.SUBPREMISE, "subpremise");
+    addressTypeToLiteralMap.put(AddressType.POSTAL_CODE, "postal_code");
+    addressTypeToLiteralMap.put(AddressType.NATURAL_FEATURE, "natural_feature");
+    addressTypeToLiteralMap.put(AddressType.AIRPORT, "airport");
+    addressTypeToLiteralMap.put(AddressType.PARK, "park");
+    addressTypeToLiteralMap.put(AddressType.POINT_OF_INTEREST, "point_of_interest");
+    addressTypeToLiteralMap.put(AddressType.POST_OFFICE, "post_office");
+    addressTypeToLiteralMap.put(AddressType.PLACE_OF_WORSHIP, "place_of_worship");
+    addressTypeToLiteralMap.put(AddressType.BUS_STATION, "bus_station");
+    addressTypeToLiteralMap.put(AddressType.TRAIN_STATION, "train_station");
+    addressTypeToLiteralMap.put(AddressType.SUBWAY_STATION, "subway_station");
+    addressTypeToLiteralMap.put(AddressType.TRANSIT_STATION, "transit_station");
+    addressTypeToLiteralMap.put(AddressType.CHURCH, "church");
+    addressTypeToLiteralMap.put(AddressType.FINANCE, "finance");
+    addressTypeToLiteralMap.put(AddressType.ESTABLISHMENT, "establishment");
+    addressTypeToLiteralMap.put(AddressType.POSTAL_TOWN, "postal_town");
+    addressTypeToLiteralMap.put(AddressType.UNIVERSITY, "university");
+
+    for (Map.Entry<AddressType, String> addressTypeLiteralPair :
+        addressTypeToLiteralMap.entrySet()) {
+      assertEquals(addressTypeLiteralPair.getValue(),
+                   addressTypeLiteralPair.getKey().toCanonicalLiteral());
+    }
+    assertEquals(addressTypeToLiteralMap.size() + 1, // 1 for unknown
+                 AddressType.values().length);
+  }
+
+  @Test
+  public void testCanonicalLiteralsForAddressComponentType() {
+    Map<AddressComponentType, String> addressComponentTypeToLiteralMap =
+        new HashMap<AddressComponentType, String>();
+    addressComponentTypeToLiteralMap.put(AddressComponentType.STREET_ADDRESS, "street_address");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ROUTE, "route");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.INTERSECTION, "intersection");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POLITICAL, "political");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.COUNTRY, "country");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1,
+                                "administrative_area_level_1");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_2,
+                                "administrative_area_level_2");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3,
+                                "administrative_area_level_3");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_4,
+                                "administrative_area_level_4");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_5,
+                                "administrative_area_level_5");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.COLLOQUIAL_AREA, "colloquial_area");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.LOCALITY, "locality");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.WARD, "ward");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY, "sublocality");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY_LEVEL_1,
+                                         "sublocality_level_1");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY_LEVEL_2,
+                                         "sublocality_level_2");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY_LEVEL_3,
+                                         "sublocality_level_3");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY_LEVEL_4,
+                                         "sublocality_level_4");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBLOCALITY_LEVEL_5,
+                                         "sublocality_level_5");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.NEIGHBORHOOD, "neighborhood");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.PREMISE, "premise");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBPREMISE, "subpremise");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POSTAL_CODE, "postal_code");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POST_BOX, "post_box");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POSTAL_CODE_PREFIX,
+                                         "postal_code_prefix");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POSTAL_CODE_SUFFIX,
+                                         "postal_code_suffix");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.NATURAL_FEATURE, "natural_feature");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.AIRPORT, "airport");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.PARK, "park");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.FLOOR, "floor");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.PARKING, "parking");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POINT_OF_INTEREST,
+                                         "point_of_interest");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.BUS_STATION, "bus_station");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.TRAIN_STATION, "train_station");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SUBWAY_STATION, "subway_station");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.TRANSIT_STATION, "transit_station");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ESTABLISHMENT, "establishment");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.POSTAL_TOWN, "postal_town");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ROOM, "room");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.STREET_NUMBER, "street_number");
+
+    for (Map.Entry<AddressComponentType, String> AddressComponentTypeLiteralPair :
+        addressComponentTypeToLiteralMap.entrySet()) {
+      assertEquals(AddressComponentTypeLiteralPair.getValue(),
+                   AddressComponentTypeLiteralPair.getKey().toCanonicalLiteral());
+    }
+    assertEquals(addressComponentTypeToLiteralMap.size() + 1, // 1 for unknown
+                 AddressComponentType.values().length);
   }
 
   private static <T extends UrlValue> void assertCannotGetUrlValue(T unknown) {


### PR DESCRIPTION
I noticed that while AddressType had the canonical literals (the exact strings in the server response), AddressComponentType didn't have them.