### PR TITLE
Add option to not retry once daily limit has been reached

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,4 +15,5 @@ Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier
 Pulkit Bhuwalka <pulkit.bosco05@gmail.com> @nutsiepully
 Romain Sertelon <romain@sertelon.fr> @rsertelon
+Sam Lukes <sam_lukes@icloud.com> @slukes
 Sipos Tamas <sipos.tamas@fhb.hu> @onlyonce

--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -41,7 +41,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
   private final URLFetchService client = URLFetchServiceFactory.getURLFetchService();
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, boolean failFastForDailyLimit) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -149,7 +149,7 @@ public class GeoApiContext {
                                                                      FieldNamingPolicy fieldNamingPolicy, String hostName, String path,
                                                                      boolean canUseClientId, String encodedPath) {
     checkContext(canUseClientId);
-    if (! encodedPath.startsWith("&")) {
+    if (!encodedPath.startsWith("&")) {
       throw new IllegalArgumentException("encodedPath must start with &");
     }
 
@@ -157,33 +157,35 @@ public class GeoApiContext {
     if (canUseClientId && clientId != null) {
       url.append("?client=").append(clientId);
     } else {
-      url.append(encodedPath);
+      url.append("?key=").append(apiKey);
+    }
+    url.append(encodedPath);
 
-      if (canUseClientId && clientId != null) {
-        try {
-          String signature = urlSigner.getSignature(url.toString());
-          url.append("&signature=").append(signature);
-        } catch (Exception e) {
-          return new ExceptionResult<T>(e);
-        }
-      }
-
-      if (baseUrlOverride != null) {
-        hostName = baseUrlOverride;
+    if (canUseClientId && clientId != null) {
+      try {
+        String signature = urlSigner.getSignature(url.toString());
+        url.append("&signature=").append(signature);
+      } catch (Exception e) {
+        return new ExceptionResult<T>(e);
       }
     }
+
+    if (baseUrlOverride != null) {
+      hostName = baseUrlOverride;
+    }
+
       return requestHandler.handle(hostName, url.toString(), USER_AGENT, clazz, fieldNamingPolicy, errorTimeout, failFastForDailyLimit);
   }
 
   private void checkContext(boolean canUseClientId) {
     if (urlSigner == null && apiKey == null) {
       throw new IllegalStateException(
-                                         "Must provide either API key or Maps for Work credentials.");
-    } else if (! canUseClientId && apiKey == null) {
+          "Must provide either API key or Maps for Work credentials.");
+    } else if (!canUseClientId && apiKey == null) {
       throw new IllegalStateException(
-                                         "API does not support client ID & secret - you must provide a key");
+          "API does not support client ID & secret - you must provide a key");
     }
-    if (urlSigner == null && ! apiKey.startsWith("AIza")) {
+    if (urlSigner == null && !apiKey.startsWith("AIza")) {
       throw new IllegalStateException("Invalid API key.");
     }
   }

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -42,6 +42,7 @@ public class GeoApiContext {
   private UrlSigner urlSigner;
   private String channel;
   private RequestHandler requestHandler;
+  private boolean failFastForDailyLimit;
 
 
   /**
@@ -53,12 +54,19 @@ public class GeoApiContext {
    * @see GaeRequestHandler
    */
   public interface RequestHandler {
-    <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout);
+    <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz,
+                                                          FieldNamingPolicy fieldNamingPolicy, long errorTimeout, boolean failFastForDailyLimit);
+
     void setConnectTimeout(long timeout, TimeUnit unit);
+
     void setReadTimeout(long timeout, TimeUnit unit);
+
     void setWriteTimeout(long timeout, TimeUnit unit);
+
     void setQueriesPerSecond(int maxQps);
+
     void setQueriesPerSecond(int maxQps, int minimumInterval);
+
     void setProxy(Proxy proxy);
   }
 
@@ -75,10 +83,9 @@ public class GeoApiContext {
   /**
    * Construct a GeoApiContext with the specified strategy for handling requests.
    *
+   * @param requestHandler How to handle URL requests to the Google Maps APIs.
    * @see OkHttpRequestHandler
    * @see GaeRequestHandler
-   *
-   * @param requestHandler How to handle URL requests to the Google Maps APIs.
    */
   public GeoApiContext(RequestHandler requestHandler) {
     this.requestHandler = requestHandler;
@@ -86,7 +93,7 @@ public class GeoApiContext {
 
   <T, R extends ApiResponse<T>> PendingResult<T> get(ApiConfig config, Class<? extends R> clazz,
                                                      Map<String, String> params) {
-    if (channel != null && !channel.isEmpty() && !params.containsKey("channel")) {
+    if (channel != null && ! channel.isEmpty() && ! params.containsKey("channel")) {
       params.put("channel", channel);
     }
 
@@ -130,7 +137,7 @@ public class GeoApiContext {
     }
 
     // Channel can be supplied per-request or per-context. We prioritize it from the request, so if it's not provided there, provide it here
-    if (!channelSet && channel != null && !channel.isEmpty()) {
+    if (! channelSet && channel != null && ! channel.isEmpty()) {
       query.append("&channel=").append(channel);
     }
 
@@ -142,7 +149,7 @@ public class GeoApiContext {
                                                                      FieldNamingPolicy fieldNamingPolicy, String hostName, String path,
                                                                      boolean canUseClientId, String encodedPath) {
     checkContext(canUseClientId);
-    if (!encodedPath.startsWith("&")) {
+    if (! encodedPath.startsWith("&")) {
       throw new IllegalArgumentException("encodedPath must start with &");
     }
 
@@ -150,35 +157,33 @@ public class GeoApiContext {
     if (canUseClientId && clientId != null) {
       url.append("?client=").append(clientId);
     } else {
-      url.append("?key=").append(apiKey);
-    }
-    url.append(encodedPath);
+      url.append(encodedPath);
 
-    if (canUseClientId && clientId != null) {
-      try {
-        String signature = urlSigner.getSignature(url.toString());
-        url.append("&signature=").append(signature);
-      } catch (Exception e) {
-        return new ExceptionResult<T>(e);
+      if (canUseClientId && clientId != null) {
+        try {
+          String signature = urlSigner.getSignature(url.toString());
+          url.append("&signature=").append(signature);
+        } catch (Exception e) {
+          return new ExceptionResult<T>(e);
+        }
+      }
+
+      if (baseUrlOverride != null) {
+        hostName = baseUrlOverride;
       }
     }
-
-    if (baseUrlOverride != null) {
-      hostName = baseUrlOverride;
-    }
-
-    return requestHandler.handle(hostName, url.toString(), USER_AGENT, clazz, fieldNamingPolicy, errorTimeout);
+      return requestHandler.handle(hostName, url.toString(), USER_AGENT, clazz, fieldNamingPolicy, errorTimeout, failFastForDailyLimit);
   }
 
   private void checkContext(boolean canUseClientId) {
     if (urlSigner == null && apiKey == null) {
       throw new IllegalStateException(
-          "Must provide either API key or Maps for Work credentials.");
-    } else if (!canUseClientId && apiKey == null) {
+                                         "Must provide either API key or Maps for Work credentials.");
+    } else if (! canUseClientId && apiKey == null) {
       throw new IllegalStateException(
-          "API does not support client ID & secret - you must provide a key");
+                                         "API does not support client ID & secret - you must provide a key");
     }
-    if (urlSigner == null && !apiKey.startsWith("AIza")) {
+    if (urlSigner == null && ! apiKey.startsWith("AIza")) {
       throw new IllegalStateException("Invalid API key.");
     }
   }
@@ -272,6 +277,20 @@ public class GeoApiContext {
    */
   public GeoApiContext setQueryRateLimit(int maxQps, int minimumInterval) {
     requestHandler.setQueriesPerSecond(maxQps, minimumInterval);
+    return this;
+  }
+
+  /**
+   * Overrides the default behaviour of retrying all over limit errors,
+   * to instead only retry rate limit errors and not daily limit errors.
+   *
+   * @param value whether or not to fail fast for daily rate limit errors.
+   */
+  public GeoApiContext setFailFastForDailyLimit(boolean value) {
+    if (this.requestHandler instanceof GaeRequestHandler) {
+      throw new RuntimeException("Fail fast for daily limit is not supported by Google App Engine");
+    }
+    this.failFastForDailyLimit = value;
     return this;
   }
 

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -56,17 +56,11 @@ public class GeoApiContext {
   public interface RequestHandler {
     <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz,
                                                           FieldNamingPolicy fieldNamingPolicy, long errorTimeout, boolean failFastForDailyLimit);
-
     void setConnectTimeout(long timeout, TimeUnit unit);
-
     void setReadTimeout(long timeout, TimeUnit unit);
-
     void setWriteTimeout(long timeout, TimeUnit unit);
-
     void setQueriesPerSecond(int maxQps);
-
     void setQueriesPerSecond(int maxQps, int minimumInterval);
-
     void setProxy(Proxy proxy);
   }
 
@@ -83,9 +77,10 @@ public class GeoApiContext {
   /**
    * Construct a GeoApiContext with the specified strategy for handling requests.
    *
-   * @param requestHandler How to handle URL requests to the Google Maps APIs.
    * @see OkHttpRequestHandler
    * @see GaeRequestHandler
+   *
+   * @param requestHandler How to handle URL requests to the Google Maps APIs.
    */
   public GeoApiContext(RequestHandler requestHandler) {
     this.requestHandler = requestHandler;
@@ -93,7 +88,7 @@ public class GeoApiContext {
 
   <T, R extends ApiResponse<T>> PendingResult<T> get(ApiConfig config, Class<? extends R> clazz,
                                                      Map<String, String> params) {
-    if (channel != null && ! channel.isEmpty() && ! params.containsKey("channel")) {
+    if (channel != null && !channel.isEmpty() && !params.containsKey("channel")) {
       params.put("channel", channel);
     }
 
@@ -137,7 +132,7 @@ public class GeoApiContext {
     }
 
     // Channel can be supplied per-request or per-context. We prioritize it from the request, so if it's not provided there, provide it here
-    if (! channelSet && channel != null && ! channel.isEmpty()) {
+    if (!channelSet && channel != null && !channel.isEmpty()) {
       query.append("&channel=").append(channel);
     }
 

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -47,7 +47,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
   }
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, boolean failFastForDailyLimit) {
     Request req = new Request.Builder()
         .get()
         .header("User-Agent", userAgent)
@@ -55,7 +55,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
     LOG.log(Level.INFO, "Request: {0}", hostName + url);
 
-    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout);
+    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, failFastForDailyLimit);
   }
 
   @Override

--- a/src/main/java/com/google/maps/errors/ApiException.java
+++ b/src/main/java/com/google/maps/errors/ApiException.java
@@ -45,7 +45,12 @@ public class ApiException extends Exception {
     } else if ("NOT_FOUND".equals(status)) {
       return new NotFoundException(errorMessage);
     } else if ("OVER_QUERY_LIMIT".equals(status)) {
-      return new OverQueryLimitException(errorMessage);
+      //Ideally the service would be changed to give a different status
+      if(errorMessage != null && errorMessage.contains("daily")){
+        return new OverDailyLimitException(errorMessage);
+      } else {
+        return new OverQueryLimitException(errorMessage);
+      }
     } else if ("REQUEST_DENIED".equals(status)) {
       return new RequestDeniedException(errorMessage);
     } else if ("UNKNOWN_ERROR".equals(status)) {

--- a/src/main/java/com/google/maps/errors/OverDailyLimitException.java
+++ b/src/main/java/com/google/maps/errors/OverDailyLimitException.java
@@ -18,7 +18,7 @@ package com.google.maps.errors;
 /**
  * Indicates that the requesting account has exceeded daily quota.
  */
-public class OverDailyLimitException extends ApiException {
+public class OverDailyLimitException extends OverQueryLimitException {
 
   public OverDailyLimitException(String errorMessage) {
     super(errorMessage);

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -134,7 +134,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
       // 0.5 * (1.5 ^ i) represents an increased sleep time of 1.5x per iteration,
       // starting at 0.5s when i = 0. The retryCounter will be 1 for the 1st retry,
       // so subtract 1 here.
-      double delaySecs = 0.5 * Math.pow(1.5, retryCounter - 1);
+      double delaySecs = 0.5 * Math.pow(1.5, retryCounter -1);
 
       // Generate a jitter value between -delaySecs / 2 and +delaySecs / 2
       long delayMillis = (long) (delaySecs * (Math.random() + 0.5) * 1000);

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -24,10 +24,25 @@ import com.google.maps.PhotoRequest;
 import com.google.maps.errors.ApiException;
 import com.google.maps.errors.OverDailyLimitException;
 import com.google.maps.errors.OverQueryLimitException;
-import com.google.maps.model.*;
+import com.google.maps.model.AddressComponentType;
+import com.google.maps.model.AddressType;
+import com.google.maps.model.Distance;
+import com.google.maps.model.Duration;
+import com.google.maps.model.Fare;
+import com.google.maps.model.LatLng;
+import com.google.maps.model.LocationType;
 import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
+import com.google.maps.model.PhotoResult;
 import com.google.maps.model.PlaceDetails.Review.AspectRating.RatingType;
-import com.squareup.okhttp.*;
+import com.google.maps.model.PriceLevel;
+import com.google.maps.model.TravelMode;
+
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Callback;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.joda.time.LocalTime;
@@ -205,9 +220,9 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
 
     // Places Photo API special case
     if (contentType != null &&
-            contentType.startsWith("image") &&
-            responseClass == PhotoRequest.Response.class &&
-            response.code() == 200) {
+        contentType.startsWith("image") &&
+        responseClass == PhotoRequest.Response.class &&
+        response.code() == 200) {
       // Photo API response is just a raw image byte array.
       PhotoResult result = new PhotoResult();
       result.contentType = contentType;
@@ -216,23 +231,23 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
     }
 
     Gson gson = new GsonBuilder()
-                    .registerTypeAdapter(DateTime.class, new DateTimeAdapter())
-                    .registerTypeAdapter(Distance.class, new DistanceAdapter())
-                    .registerTypeAdapter(Duration.class, new DurationAdapter())
-                    .registerTypeAdapter(Fare.class, new FareAdapter())
-                    .registerTypeAdapter(LatLng.class, new LatLngAdapter())
-                    .registerTypeAdapter(AddressComponentType.class,
-                        new SafeEnumAdapter<AddressComponentType>(AddressComponentType.UNKNOWN))
-                    .registerTypeAdapter(AddressType.class, new SafeEnumAdapter<AddressType>(AddressType.UNKNOWN))
-                    .registerTypeAdapter(TravelMode.class, new SafeEnumAdapter<TravelMode>(TravelMode.UNKNOWN))
-                    .registerTypeAdapter(LocationType.class, new SafeEnumAdapter<LocationType>(LocationType.UNKNOWN))
-                    .registerTypeAdapter(RatingType.class, new SafeEnumAdapter<RatingType>(RatingType.UNKNOWN))
-                    .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdaptor())
-                    .registerTypeAdapter(PriceLevel.class, new PriceLevelAdaptor())
-                    .registerTypeAdapter(Instant.class, new InstantAdapter())
-                    .registerTypeAdapter(LocalTime.class, new LocalTimeAdapter())
-                    .setFieldNamingPolicy(fieldNamingPolicy)
-                    .create();
+        .registerTypeAdapter(DateTime.class, new DateTimeAdapter())
+        .registerTypeAdapter(Distance.class, new DistanceAdapter())
+        .registerTypeAdapter(Duration.class, new DurationAdapter())
+        .registerTypeAdapter(Fare.class, new FareAdapter())
+        .registerTypeAdapter(LatLng.class, new LatLngAdapter())
+        .registerTypeAdapter(AddressComponentType.class,
+            new SafeEnumAdapter<AddressComponentType>(AddressComponentType.UNKNOWN))
+        .registerTypeAdapter(AddressType.class, new SafeEnumAdapter<AddressType>(AddressType.UNKNOWN))
+        .registerTypeAdapter(TravelMode.class, new SafeEnumAdapter<TravelMode>(TravelMode.UNKNOWN))
+        .registerTypeAdapter(LocationType.class, new SafeEnumAdapter<LocationType>(LocationType.UNKNOWN))
+        .registerTypeAdapter(RatingType.class, new SafeEnumAdapter<RatingType>(RatingType.UNKNOWN))
+        .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdaptor())
+        .registerTypeAdapter(PriceLevel.class, new PriceLevelAdaptor())
+        .registerTypeAdapter(Instant.class, new InstantAdapter())
+        .registerTypeAdapter(LocalTime.class, new LocalTimeAdapter())
+        .setFieldNamingPolicy(fieldNamingPolicy)
+        .create();
 
     // Attempt to de-serialize before checking the HTTP status code, as there may be JSON in the
     // body that we can use to provide a more descriptive exception.
@@ -240,7 +255,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
       resp = gson.fromJson(new String(bytes, "utf8"), responseClass);
     } catch (JsonSyntaxException e) {
       // Check HTTP status for a more suitable exception
-      if (! response.isSuccessful()) {
+      if (!response.isSuccessful()) {
         // Some of the APIs return 200 even when the API request fails, as long as the transport
         // mechanism succeeds. In these cases, INVALID_RESPONSE, etc are handled by the Gson
         // parsing.

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -294,7 +294,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     int bytesRead;
     byte[] data = new byte[8192];
-    while ((bytesRead = in.read(data, 0, data.length)) != - 1) {
+    while ((bytesRead = in.read(data, 0, data.length)) != -1) {
       buffer.write(data, 0, bytesRead);
     }
     buffer.flush();

--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -22,6 +22,7 @@ import com.google.maps.model.GeocodingResult;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
 import com.google.mockwebserver.RecordedRequest;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 

--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -15,6 +15,10 @@
 
 package com.google.maps;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import com.google.maps.errors.OverDailyLimitException;
 import com.google.maps.internal.ApiConfig;
 import com.google.maps.internal.ApiResponse;
@@ -22,7 +26,6 @@ import com.google.maps.model.GeocodingResult;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
 import com.google.mockwebserver.RecordedRequest;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -33,7 +36,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -15,18 +15,13 @@
 
 package com.google.maps;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-
+import com.google.maps.errors.OverDailyLimitException;
 import com.google.maps.internal.ApiConfig;
 import com.google.maps.internal.ApiResponse;
 import com.google.maps.model.GeocodingResult;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
 import com.google.mockwebserver.RecordedRequest;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -35,6 +30,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 @Category(MediumTests.class)
 public class GeoApiContextTest {
@@ -187,6 +187,34 @@ public class GeoApiContextTest {
     } catch (IOException ioe) {
       // Ensure the message matches the status line in the mock responses.
       assertEquals("Server Error: 500 Internal server error", ioe.getMessage());
+      return;
+    }
+    fail("Internal server error was expected but not observed.");
+  }
+
+  @Test
+  public void testFastFailForDailyLimit() throws Exception {
+    MockResponse errorResponse = new MockResponse();
+    errorResponse.setStatus("HTTP/1.1 400 Internal server error");
+    errorResponse.setBody(TestUtils.retrieveBody("OverDailyLimitResponse.json"));
+
+    // Enqueue some error responses.
+    // Although only one of them should be used
+    for (int i = 0; i < 10; i++) {
+      server.enqueue(errorResponse);
+    }
+    server.play();
+
+    // Wire the mock web server to the context
+    setMockBaseUrl();
+    context.setRetryTimeout(5, TimeUnit.SECONDS)
+    .setFailFastForDailyLimit(true);
+
+    try {
+      context.get(new ApiConfig("/"), GeocodingApi.Response.class, "k", "v").await();
+    } catch (OverDailyLimitException e) {
+      //Ensure that only one request was sent
+      assertThat(server.getRequestCount(), is(equalTo(1)));
       return;
     }
     fail("Internal server error was expected but not observed.");

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -15,12 +15,31 @@
 
 package com.google.maps;
 
-import com.google.maps.model.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.maps.model.AddressComponentType;
+import com.google.maps.model.AutocompletePrediction;
+import com.google.maps.model.ComponentFilter;
+import com.google.maps.model.LatLng;
 import com.google.maps.model.OpeningHours.Period;
 import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
+import com.google.maps.model.Photo;
+import com.google.maps.model.PlaceAutocompleteType;
+import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceDetails.Review.AspectRating.RatingType;
+import com.google.maps.model.PlaceIdScope;
+import com.google.maps.model.PlaceType;
+import com.google.maps.model.PlacesSearchResponse;
+import com.google.maps.model.PlacesSearchResult;
+import com.google.maps.model.PriceLevel;
+import com.google.maps.model.RankBy;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
+
+
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.joda.time.LocalTime;
@@ -33,7 +52,6 @@ import java.net.URI;
 import java.util.List;
 
 import static com.google.maps.TestUtils.retrieveBody;
-import static org.junit.Assert.*;
 
 public class PlacesApiTest {
 

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -15,32 +15,12 @@
 
 package com.google.maps;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import com.google.maps.model.AddressComponentType;
-import com.google.maps.model.AddressType;
-import com.google.maps.model.AutocompletePrediction;
-import com.google.maps.model.ComponentFilter;
-import com.google.maps.model.LatLng;
+import com.google.maps.model.*;
 import com.google.maps.model.OpeningHours.Period;
 import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
-import com.google.maps.model.Photo;
-import com.google.maps.model.PlaceAutocompleteType;
-import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceDetails.Review.AspectRating.RatingType;
-import com.google.maps.model.PlaceIdScope;
-import com.google.maps.model.PlaceType;
-import com.google.maps.model.PlacesSearchResponse;
-import com.google.maps.model.PlacesSearchResult;
-import com.google.maps.model.PriceLevel;
-import com.google.maps.model.RankBy;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
-
-
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.joda.time.LocalTime;
@@ -49,10 +29,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
-import java.util.Scanner;
+
+import static com.google.maps.TestUtils.retrieveBody;
+import static org.junit.Assert.*;
 
 public class PlacesApiTest {
 
@@ -76,16 +57,6 @@ public class PlacesApiTest {
     queryAutocompleteWithPlaceIdResponseBody = retrieveBody("QueryAutocompleteResponseWithPlaceID.json");
     textSearchResponseBody = retrieveBody("TextSearchResponse.json");
     textSearchPizzaInNYCbody = retrieveBody("TextSearchPizzaInNYC.json");
-  }
-
-  private String retrieveBody(String filename) {
-    InputStream input = this.getClass().getResourceAsStream(filename);
-    Scanner s = new java.util.Scanner(input).useDelimiter("\\A");
-    String body = s.next();
-    if (body == null || body.length() == 0) {
-      throw new IllegalArgumentException("filename '" + filename + "' resulted in null or empty body");
-    }
-    return body;
   }
 
   private MockWebServer server;

--- a/src/test/java/com/google/maps/TestUtils.java
+++ b/src/test/java/com/google/maps/TestUtils.java
@@ -1,0 +1,16 @@
+package com.google.maps;
+
+import java.io.InputStream;
+import java.util.Scanner;
+
+public class TestUtils {
+  public static String retrieveBody(String filename) {
+    InputStream input = TestUtils.class.getResourceAsStream(filename);
+    Scanner s = new java.util.Scanner(input).useDelimiter("\\A");
+    String body = s.next();
+    if (body == null || body.length() == 0) {
+      throw new IllegalArgumentException("filename '" + filename + "' resulted in null or empty body");
+    }
+    return body;
+  }
+}

--- a/src/test/resources/com/google/maps/OverDailyLimitResponse.json
+++ b/src/test/resources/com/google/maps/OverDailyLimitResponse.json
@@ -1,0 +1,7 @@
+{
+  "destination_addresses" : [],
+  "error_message" : "You have exceeded your daily request quota for this API.",
+  "origin_addresses" : [],
+  "rows" : [],
+  "status" : "OVER_QUERY_LIMIT"
+}


### PR DESCRIPTION
This pull request addresses:
https://github.com/googlemaps/google-maps-services-java/issues/156

Which I realised there was already a pull request for after doing this work, however I note that the other pull request has not been merged - I hope this one will be.

- GeoApiContext now has an option to `failFastForDailyLimit` - i.e. to immediately throw an exception if a message containing `daily` comes with an error of  `OVER_QUERY_LIMIT`
- OverDailyLimitException has been changed to subclass OverQueryLimitException so that code, including my own which relies on the exception that is currently thrown can carry on working correctly.
- Unit test has been added
