### PR TITLE
Made API results serializable for caching

### DIFF
--- a/src/main/java/com/google/maps/model/Bounds.java
+++ b/src/main/java/com/google/maps/model/Bounds.java
@@ -15,10 +15,12 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The north east and south west points that delineate the outer bounds of a map.
  */
-public class Bounds {
+public class Bounds implements Serializable {
   public LatLng northeast;
   public LatLng southwest;
 }

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -17,13 +17,15 @@ package com.google.maps.model;
 
 import org.joda.time.DateTime;
 
+import java.io.Serializable;
+
 /**
  * A component of a Directions API result.
  *
  * See <a href="https://developers.google.com/maps/documentation/directions/#Legs">the Legs
  * documentation</a> for more detail.
  */
-public class DirectionsLeg {
+public class DirectionsLeg implements Serializable {
 
   /**
    * {@code steps[]} contains an array of steps denoting information about each separate step of the

--- a/src/main/java/com/google/maps/model/DirectionsResult.java
+++ b/src/main/java/com/google/maps/model/DirectionsResult.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * DirectionsResult represents a result from the Google Directions API Web Service.
  *
  * <p>Please see <a href="https://developers.google.com/maps/documentation/directions/intro">
  * Directions API</a> for more detail.</p>
  */
-public class DirectionsResult {
+public class DirectionsResult implements Serializable {
 
   /**
    * {@code geocodedWaypoints} contains an array with details about the geocoding of origin,

--- a/src/main/java/com/google/maps/model/DirectionsRoute.java
+++ b/src/main/java/com/google/maps/model/DirectionsRoute.java
@@ -15,6 +15,8 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * A Directions API result. When the Directions API returns results, it places them within a routes
  * array. Even if the service returns no results (such as if the origin and/or destination doesn't
@@ -23,7 +25,7 @@ package com.google.maps.model;
  * <p>Please see <a href="https://developers.google.com/maps/documentation/directions/#Routes">
  * Routes</a> for more detail.
  */
-public class DirectionsRoute {
+public class DirectionsRoute implements Serializable {
   /**
    * {@code summary} contains a short textual description for the route, suitable for naming and
    * disambiguating the route from alternatives.

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -15,6 +15,8 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * Each element in the steps of a {@link DirectionsLeg} defines a single step of the calculated
  * directions. A step is the most atomic unit of a direction's route, containing a single step
@@ -33,7 +35,7 @@ package com.google.maps.model;
  * walking directions for that route in the {@code steps} array, such as: "Head north-west", "Turn
  * left onto Arelious Walker", and "Turn left onto Innes Ave".
  */
-public class DirectionsStep {
+public class DirectionsStep implements Serializable {
 
   /**
    * {@code htmlInstructions} contains formatted instructions for this step, presented as an HTML

--- a/src/main/java/com/google/maps/model/Distance.java
+++ b/src/main/java/com/google/maps/model/Distance.java
@@ -15,10 +15,12 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The distance component for Directions API results.
  */
-public class Distance {
+public class Distance implements Serializable {
 
   /**
    * This is the numeric distance, always in meters. This is intended to be used only in algorithmic

--- a/src/main/java/com/google/maps/model/DistanceMatrix.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrix.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * A complete result from a Distance Matrix API call.
  *
  * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#DistanceMatrixResponses">
  * Distance Matrix Results</a>
  */
-public class DistanceMatrix {
+public class DistanceMatrix implements Serializable {
 
   /**
    * {@code originAddresses} contains an array of addresses as returned by the API from your

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * A single result corresponding to a origin/destination pair in a Distance Matrix response.
  *
  * <p>Be sure to check the status for each element, as a matrix response can have a mix of
  * successful and failed elements depending on the connectivity of the origin and destination.
  */
-public class DistanceMatrixElement {
+public class DistanceMatrixElement implements Serializable {
 
   /**
    * {@code status} indicates the status of the request for this origin/destination pair.

--- a/src/main/java/com/google/maps/model/DistanceMatrixRow.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixRow.java
@@ -15,11 +15,13 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * Represents a single row in a Distance Matrix API response. A row represents the results for a
  * single origin.
  */
-public class DistanceMatrixRow {
+public class DistanceMatrixRow implements Serializable {
 
   /**
    * {@code elements} contains the results for this row, or individual origin.

--- a/src/main/java/com/google/maps/model/Duration.java
+++ b/src/main/java/com/google/maps/model/Duration.java
@@ -15,10 +15,12 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The duration component for Directions API results.
  */
-public class Duration {
+public class Duration implements Serializable {
 
   /**
    * This is the numeric duration, in seconds. This is intended to be used only in algorithmic

--- a/src/main/java/com/google/maps/model/EncodedPolyline.java
+++ b/src/main/java/com/google/maps/model/EncodedPolyline.java
@@ -17,6 +17,7 @@ package com.google.maps.model;
 
 import com.google.maps.internal.PolylineEncoding;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -25,7 +26,7 @@ import java.util.List;
  * <p>See <a href="https://developers.google.com/maps/documentation/utilities/polylinealgorithm">
  * Encoded Polyline Algorithm</a> for more detail on the protocol.
  */
-public class EncodedPolyline {
+public class EncodedPolyline implements Serializable {
   private final String points;
 
   /**

--- a/src/main/java/com/google/maps/model/Fare.java
+++ b/src/main/java/com/google/maps/model/Fare.java
@@ -15,6 +15,7 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Currency;
 
@@ -24,7 +25,7 @@ import java.util.Currency;
  * See <a href="https://developers.google.com/maps/documentation/directions/#Routes">the Routes
  * Documentation</a> for more detail.
  */
-public class Fare {
+public class Fare implements Serializable {
 
   /**
    * {@code currency} contains the currency indicating the currency that the amount is expressed

--- a/src/main/java/com/google/maps/model/GeocodedWaypoint.java
+++ b/src/main/java/com/google/maps/model/GeocodedWaypoint.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * Geocoded Waypoint represents a point in a Directions API response, either the origin, one of the
  * requested waypoints, or the destination. Please see
  * <a href="https://developers.google.com/maps/documentation/directions/intro#GeocodedWaypoints">
  *   Geocoded Waypoints</a> for more detail.
  */
-public class GeocodedWaypoint {
+public class GeocodedWaypoint implements Serializable {
   /**
    * {@code geocoderStatus} indicates the status code resulting from the geocoding operation.
    */

--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -17,12 +17,13 @@ package com.google.maps.model;
 
 import com.google.maps.internal.StringJoin.UrlValue;
 
+import java.io.Serializable;
 import java.util.Locale;
 
 /**
  * A place on Earth, represented by a Latitude/Longitude pair.
  */
-public class LatLng implements UrlValue {
+public class LatLng implements UrlValue, Serializable {
 
   /**
    * The latitude of this location.

--- a/src/main/java/com/google/maps/model/StopDetails.java
+++ b/src/main/java/com/google/maps/model/StopDetails.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The stop/station.
  *
  * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
  * Transit details</a> for more detail.
  */
-public class StopDetails {
+public class StopDetails implements Serializable {
 
   /**
    * The name of the transit station/stop. eg. "Union Square".

--- a/src/main/java/com/google/maps/model/TransitAgency.java
+++ b/src/main/java/com/google/maps/model/TransitAgency.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The operator of a line.
  *
  * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
  * Transit details</a> for more detail.
  */
-public class TransitAgency {
+public class TransitAgency implements Serializable {
 
   /**
    * {@code name} contains the name of the transit agency.

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -17,6 +17,8 @@ package com.google.maps.model;
 
 import org.joda.time.DateTime;
 
+import java.io.Serializable;
+
 /**
  * Transit directions return additional information that is not relevant for other modes of
  * transportation. These additional properties are exposed through the {@code transit_details}
@@ -24,7 +26,7 @@ import org.joda.time.DateTime;
  * TransitDetails} object you can access additional information about the transit stop, transit line
  * and transit agency.
  */
-public class TransitDetails {
+public class TransitDetails implements Serializable {
 
   /**
    * {@code arrivalStop} contains information about the arrival stop/station for this part of the

--- a/src/main/java/com/google/maps/model/TransitLine.java
+++ b/src/main/java/com/google/maps/model/TransitLine.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The transit line used in a step.
  *
  * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
  * Transit details</a> for more detail.
  */
-public class TransitLine {
+public class TransitLine implements Serializable {
 
   /**
    * {@code name} contains the full name of this transit line. eg. "7 Avenue Express".

--- a/src/main/java/com/google/maps/model/Vehicle.java
+++ b/src/main/java/com/google/maps/model/Vehicle.java
@@ -15,13 +15,15 @@
 
 package com.google.maps.model;
 
+import java.io.Serializable;
+
 /**
  * The vehicle used on a line.
  *
  * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
  * Transit details</a> for more detail.
  */
-public class Vehicle {
+public class Vehicle implements Serializable {
 
   /**
    * {@code name} contains the name of the vehicle on this line. eg. "Subway."


### PR DESCRIPTION
For performance reasons we need to store Google Directions and Distance Matrix results in memcached. Having results implement Serializable makes it easier to work with Java memcached library.