### PR TITLE
Set RateLimitExecutor thread name.

### DIFF
--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -59,6 +59,7 @@ public class RateLimitExecutorService implements ExecutorService, Runnable {
     setQueriesPerSecond(DEFAULT_QUERIES_PER_SECOND);
     Thread delayThread = new Thread(this);
     delayThread.setDaemon(true);
+    delayThread.setName("RateLimitExecutorDelayThread");
     delayThread.start();
   }
 


### PR DESCRIPTION
RateLimitExecutorService thread doesn't has a name (oversight?). 
It is not a bug, but it is easer to read stacktraces with thread with names.
