### PR TITLE
Test library stuck

### DIFF
--- a/src/test/java/com/google/maps/MultipleGeocodingTest.java
+++ b/src/test/java/com/google/maps/MultipleGeocodingTest.java
@@ -1,0 +1,90 @@
+package com.google.maps;
+
+import com.google.maps.model.GeocodingResult;
+import com.google.maps.model.LocationType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by iblesa on 21/06/2016.
+ */
+public class MultipleGeocodingTest extends AuthenticatedTest {
+
+    private static final double EPSILON = 0.000001;
+    private GeoApiContext context;
+
+    public MultipleGeocodingTest(GeoApiContext context) {
+        this.context = context
+                .setQueryRateLimit(3)
+                .setConnectTimeout(1, TimeUnit.SECONDS)
+                .setReadTimeout(1, TimeUnit.SECONDS)
+                .setWriteTimeout(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testMultipleAsync() throws Exception {
+        final List<GeocodingResult[]> resps = new ArrayList<GeocodingResult[]>();
+        final List<Throwable> errors = new ArrayList<Throwable>();
+        int limit = 2500;
+        int batchSize = 100;
+
+        batchSize = Math.min(batchSize, limit);
+
+        int maxBatches = limit / batchSize;
+        for (int batch = 0; batch < maxBatches; batch++) {
+//            System.out.println("Batch " + batch);
+            int start = batch * batchSize;
+            int end = (batch + 1) * batchSize;
+//            System.out.println(" Lets start at " + start + " and end at " + end);
+            for (int i = start; i < end; i++) {
+                PendingResult.Callback<GeocodingResult[]> callback =
+                        new PendingResult.Callback<GeocodingResult[]>() {
+                            @Override
+                            public void onResult(GeocodingResult[] result) {
+                                resps.add(result);
+                            }
+
+                            @Override
+                            public void onFailure(Throwable e) {
+                                errors.add(e);
+                                fail("Got error when expected success.");
+                            }
+                        };
+                GeocodingApi.newRequest(context).address("Sydney").setCallback(callback);
+            }
+            if (errors.isEmpty()) {
+                Thread.sleep(10000);
+            } else {
+                break;
+            }
+        }
+
+        assertFalse(resps.isEmpty());
+        assertTrue(errors.isEmpty());
+        assertNotNull(resps.get(0));
+        Set<GeocodingResult[]> all = new HashSet<GeocodingResult[]>(resps);
+        for (GeocodingResult[] result : all) {
+            checkSydneyResult(result);
+
+        }
+    }
+
+    private void checkSydneyResult(GeocodingResult[] results) {
+        assertNotNull(results);
+        assertNotNull(results[0].geometry);
+        assertNotNull(results[0].geometry.location);
+        assertEquals(-33.8674869, results[0].geometry.location.lat, EPSILON);
+        assertEquals(151.2069902, results[0].geometry.location.lng, EPSILON);
+        assertEquals("ChIJP3Sa8ziYEmsRUKgyFmh9AQM", results[0].placeId);
+        assertEquals(LocationType.APPROXIMATE, results[0].geometry.locationType);
+    }
+
+}

--- a/src/test/java/com/google/maps/MultipleGeocodingTest.java
+++ b/src/test/java/com/google/maps/MultipleGeocodingTest.java
@@ -67,9 +67,10 @@ public class MultipleGeocodingTest extends AuthenticatedTest {
             }
         }
 
-        assertFalse(resps.isEmpty());
-        assertTrue(errors.isEmpty());
-        assertNotNull(resps.get(0));
+        assertFalse("We must get responses", resps.isEmpty());
+        assertTrue("We cannot receive errors", errors.isEmpty());
+        assertNotNull("First result is not null", resps.get(0));
+        assertEquals("We have expected number of results", limit, resps.size());
         Set<GeocodingResult[]> all = new HashSet<GeocodingResult[]>(resps);
         for (GeocodingResult[] result : all) {
             checkSydneyResult(result);
@@ -81,8 +82,8 @@ public class MultipleGeocodingTest extends AuthenticatedTest {
         assertNotNull(results);
         assertNotNull(results[0].geometry);
         assertNotNull(results[0].geometry.location);
-        assertEquals(-33.8674869, results[0].geometry.location.lat, EPSILON);
-        assertEquals(151.2069902, results[0].geometry.location.lng, EPSILON);
+        assertEquals(-33.8688197, results[0].geometry.location.lat, EPSILON);
+        assertEquals(151.2092955, results[0].geometry.location.lng, EPSILON);
         assertEquals("ChIJP3Sa8ziYEmsRUKgyFmh9AQM", results[0].placeId);
         assertEquals(LocationType.APPROXIMATE, results[0].geometry.locationType);
     }


### PR DESCRIPTION
I just updated the test with some changes and rebase it on last changes made on the library that deal with resource management. Doing those changes closed my previous pull request. (https://github.com/googlemaps/google-maps-services-java/pull/165)

Those changes did not help with this test. it keeps getting stuck even with last changes.

Once you get an error the library tries to retry the request and it never comes back.

Not sure what is the expected behaviour of the methods that set timeouts on the GeoApiContext

In my test I set these values to 1 second. But it does not make any difference. I would expect an error return if these timeouts expire.

```
                .setConnectTimeout(1, TimeUnit.SECONDS)
                .setReadTimeout(1, TimeUnit.SECONDS)
                .setWriteTimeout(1, TimeUnit.SECONDS);
```

Sep 27, 2016 10:55:22 AM com.google.maps.OkHttpRequestHandler handle
INFO: Request: https://maps.googleapis.com/maps/api/geocode/json?key=API_KEY&address=Sydney
Sep 27, 2016 10:55:22 AM com.google.maps.OkHttpRequestHandler handle
INFO: Request: https://maps.googleapis.com/maps/api/geocode/json?key=API_KEY&address=Sydney
Sep 27, 2016 10:55:22 AM com.google.maps.OkHttpRequestHandler handle
INFO: Request: https://maps.googleapis.com/maps/api/geocode/json?key=API_KEY&address=Sydney
Sep 27, 2016 10:55:22 AM com.google.maps.OkHttpRequestHandler handle
INFO: Request: https://maps.googleapis.com/maps/api/geocode/json?key=API_KEY&address=Sydney
Sep 27, 2016 10:55:23 AM com.google.maps.internal.OkHttpPendingResult retry
INFO: Retrying request. Retry #1

Test will fail after the timeout for running the test expires

`Thread.sleep(10000);`
