### PR TITLE
Allow retries to be limited by number of retries, not time.

### DIFF
--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -42,7 +42,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
   private final URLFetchService client = URLFetchServiceFactory.getURLFetchService();
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {
@@ -52,11 +52,11 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw(new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout);
+    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
   }
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {
@@ -68,7 +68,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw(new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout);
+    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
   }
 
 

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -50,7 +50,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
   }
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
     Request req = new Request.Builder()
         .get()
         .header("User-Agent", userAgent)
@@ -58,17 +58,17 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
     LOG.log(Level.INFO, "Request: {0}", hostName + url);
 
-    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout);
+    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
   }
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
     RequestBody body = RequestBody.create(JSON, payload);
     Request req = new Request.Builder()
         .post(body)
         .header("User-Agent", userAgent)
         .url(hostName + url).build();
 
-    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout);
+    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
   }
   @Override
   public void setConnectTimeout(long timeout, TimeUnit unit) {


### PR DESCRIPTION
In some cases, it can be useful to restrict the number of retries by retry count, not just time. This pull request adds `GeoApiContext.setMaxRetries(Integer)` and `GeoApiContext.disableRetries()`.

This does not remove the ability to limit retries by time.