### PR TITLE
Allow specific exception types to be retried or not retried

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,4 +15,5 @@ Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier
 Pulkit Bhuwalka <pulkit.bosco05@gmail.com> @nutsiepully
 Romain Sertelon <romain@sertelon.fr> @rsertelon
+Sam Lukes <sam_lukes@icloud.com> @slukes
 Sipos Tamas <sipos.tamas@fhb.hu> @onlyonce

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@
 
 # Please keep the list sorted by first name.
 
+Amy Boyd <amy@amyboyd.co.uk> @amyboyd
 Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady

--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ down requests, you can do that too, using `new GeoApiContext().setQueryRateLimit
 Automatically retry when intermittent failures occur. That is, when any of the retriable 5xx errors
 are returned from the API.
 
+To alter or disable automatic retries, see these methods in `GeoApiContext`:
+
+* `.disableRetries()`
+* `.setMaxRetries()`
+* `.setRetryTimeout()`
+* `.toggleifExceptionIsAllowedToRetry()`
+
 ### Client IDs
 
 Google Maps APIs Premium Plan customers can use their [client ID and secret][clientid] to authenticate,

--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -23,6 +23,7 @@ import com.google.appengine.api.urlfetch.URLFetchService;
 import com.google.appengine.api.urlfetch.URLFetchServiceFactory;
 import com.google.gson.FieldNamingPolicy;
 import com.google.maps.internal.ApiResponse;
+import com.google.maps.internal.ExceptionsAllowedToRetry;
 import com.google.maps.internal.GaePendingResult;
 
 import java.net.MalformedURLException;
@@ -42,7 +43,10 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
   private final URLFetchService client = URLFetchServiceFactory.getURLFetchService();
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent,
+                                                               Class<R> clazz, FieldNamingPolicy fieldNamingPolicy,
+                                                               long errorTimeout, Integer maxRetries,
+                                                               ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {
@@ -52,11 +56,15 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw(new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
+    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload,
+                                                                   String userAgent, Class<R> clazz,
+                                                                   FieldNamingPolicy fieldNamingPolicy,
+                                                                   long errorTimeout, Integer maxRetries,
+                                                                   ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {
@@ -68,7 +76,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw(new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
+    return new GaePendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
 

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -17,6 +17,7 @@ package com.google.maps;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.maps.internal.ApiResponse;
+import com.google.maps.internal.ExceptionsAllowedToRetry;
 import com.google.maps.internal.OkHttpPendingResult;
 import com.google.maps.internal.RateLimitExecutorService;
 import com.squareup.okhttp.Dispatcher;
@@ -50,7 +51,10 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
   }
 
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handle(String hostName, String url, String userAgent,
+                                                               Class<R> clazz, FieldNamingPolicy fieldNamingPolicy,
+                                                               long errorTimeout, Integer maxRetries,
+                                                               ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
     Request req = new Request.Builder()
         .get()
         .header("User-Agent", userAgent)
@@ -58,18 +62,24 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
     LOG.log(Level.INFO, "Request: {0}", hostName + url);
 
-    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
+    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
+
   @Override
-  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload, String userAgent, Class<R> clazz, FieldNamingPolicy fieldNamingPolicy, long errorTimeout, Integer maxRetries) {
+  public <T, R extends ApiResponse<T>> PendingResult<T> handlePost(String hostName, String url, String payload,
+                                                                   String userAgent, Class<R> clazz,
+                                                                   FieldNamingPolicy fieldNamingPolicy,
+                                                                   long errorTimeout, Integer maxRetries,
+                                                                   ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
     RequestBody body = RequestBody.create(JSON, payload);
     Request req = new Request.Builder()
         .post(body)
         .header("User-Agent", userAgent)
         .url(hostName + url).build();
 
-    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries);
+    return new OkHttpPendingResult<T, R>(req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
+
   @Override
   public void setConnectTimeout(long timeout, TimeUnit unit) {
     client.setConnectTimeout(timeout, unit);

--- a/src/main/java/com/google/maps/internal/ExceptionsAllowedToRetry.java
+++ b/src/main/java/com/google/maps/internal/ExceptionsAllowedToRetry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.google.maps.internal;
+
+import com.google.maps.errors.ApiException;
+
+import java.util.HashSet;
+
+final public class ExceptionsAllowedToRetry extends HashSet<Class<? extends ApiException>> {
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder().append("ExceptionsAllowedToRetry[");
+
+    Object[] array = toArray();
+    for (int i = 0; i < array.length; i++) {
+      sb.append(array[i]);
+      if (i < array.length - 1) {
+        sb.append(", ");
+      }
+    }
+
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/google/maps/internal/GaePendingResult.java
+++ b/src/main/java/com/google/maps/internal/GaePendingResult.java
@@ -66,6 +66,7 @@ public class GaePendingResult<T, R extends ApiResponse<T>>
   private final Class<R> responseClass;
   private final FieldNamingPolicy fieldNamingPolicy;
   private final Integer maxRetries;
+  private final ExceptionsAllowedToRetry exceptionsAllowedToRetry;
 
   private Callback<T> callback;
   private long errorTimeOut;
@@ -85,13 +86,15 @@ public class GaePendingResult<T, R extends ApiResponse<T>>
    * @param maxRetries        Number of times allowed to re-send erroring requests.
    */
   public GaePendingResult(HTTPRequest request, URLFetchService client, Class<R> responseClass,
-                          FieldNamingPolicy fieldNamingPolicy, long errorTimeOut, Integer maxRetries) {
+                          FieldNamingPolicy fieldNamingPolicy, long errorTimeOut, Integer maxRetries,
+                          ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
     this.request = request;
     this.client = client;
     this.responseClass = responseClass;
     this.fieldNamingPolicy = fieldNamingPolicy;
     this.errorTimeOut = errorTimeOut;
     this.maxRetries = maxRetries;
+    this.exceptionsAllowedToRetry = exceptionsAllowedToRetry;
 
     this.call = client.fetchAsync(request);
   }
@@ -223,7 +226,7 @@ public class GaePendingResult<T, R extends ApiResponse<T>>
   }
 
   private boolean shouldRetry(ApiException exception) {
-    return exception instanceof OverQueryLimitException
+    return exceptionsAllowedToRetry.contains(exception.getClass())
         && cumulativeSleepTime < errorTimeOut
         && (maxRetries == null || retryCounter < maxRetries);
   }

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -49,10 +49,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
-import java.util.Scanner;
+
+import static com.google.maps.TestUtils.retrieveBody;
 
 public class PlacesApiTest {
 
@@ -79,16 +79,6 @@ public class PlacesApiTest {
     queryAutocompleteWithPlaceIdResponseBody = retrieveBody("QueryAutocompleteResponseWithPlaceID.json");
     textSearchResponseBody = retrieveBody("TextSearchResponse.json");
     textSearchPizzaInNYCbody = retrieveBody("TextSearchPizzaInNYC.json");
-  }
-
-  private String retrieveBody(String filename) {
-    InputStream input = this.getClass().getResourceAsStream(filename);
-    Scanner s = new java.util.Scanner(input).useDelimiter("\\A");
-    String body = s.next();
-    if (body == null || body.length() == 0) {
-      throw new IllegalArgumentException("filename '" + filename + "' resulted in null or empty body");
-    }
-    return body;
   }
 
   private MockWebServer server;

--- a/src/test/java/com/google/maps/TestUtils.java
+++ b/src/test/java/com/google/maps/TestUtils.java
@@ -1,0 +1,16 @@
+package com.google.maps;
+
+import java.io.InputStream;
+import java.util.Scanner;
+
+public class TestUtils {
+  public static String retrieveBody(String filename) {
+    InputStream input = TestUtils.class.getResourceAsStream(filename);
+    Scanner s = new java.util.Scanner(input).useDelimiter("\\A");
+    String body = s.next();
+    if (body == null || body.length() == 0) {
+      throw new IllegalArgumentException("filename '" + filename + "' resulted in null or empty body");
+    }
+    return body;
+  }
+}

--- a/src/test/resources/com/google/maps/OverQueryLimitResponse.json
+++ b/src/test/resources/com/google/maps/OverQueryLimitResponse.json
@@ -1,0 +1,4 @@
+{
+  "error_message" : "Please wait.",
+  "status" : "OVER_QUERY_LIMIT"
+}


### PR DESCRIPTION
PR #168 hasn't been updated in 2 months so it seems to be abandoned. This PR adds basically the same functionality - but this also allows you to customise which exceptions are retries or not.

By default only `OverQueryLimitException` will be retried. If you don't want to retry after a `OverQueryLimitException` (maybe you are in time-sensitive situation where you want to fail fast), you can disable retries with `toggleifExceptionIsAllowedToRetry(OverQueryLimitException.class, false)`. The same goes for other exception types.