### PR TITLE
Update documentation links that were outdated.

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -30,7 +30,7 @@ import com.google.maps.model.GeocodedWaypoint;
  * text strings (e.g. "Chicago, IL" or "Darwin, NT, Australia") or as latitude/longitude
  * coordinates. The Directions API can return multi-part directions using a series of waypoints.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/">documentation</a>.
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro">documentation</a>.
  */
 public class DirectionsApi {
   static final ApiConfig API_CONFIG = new ApiConfig("/maps/api/directions/json");
@@ -80,7 +80,7 @@ public class DirectionsApi {
    * Directions may be calculated that adhere to certain restrictions. This is configured by calling
    * {@link com.google.maps.DirectionsApiRequest#avoid} or {@link com.google.maps.DistanceMatrixApiRequest#avoid}.
    *
-   * @see <a href="https://developers.google.com/maps/documentation/directions/#Restrictions">
+   * @see <a href="https://developers.google.com/maps/documentation/directions/intro#Restrictions">
    * Restrictions in the Directions API</a>
    * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#Restrictions">
    * Restrictions in the Distance Matrix API</a>

--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -154,7 +154,7 @@ public class DirectionsApiRequest
    * which will be geocoded. Waypoints are only supported for driving, walking and bicycling
    * directions.
    *
-   * <p>For more information on waypoints, see <a href="https://developers.google.com/maps/documentation/directions/#Waypoints">
+   * <p>For more information on waypoints, see <a href="https://developers.google.com/maps/documentation/directions/intro#Waypoints">
    * Using Waypoints in Routes</a>.
    */
   public DirectionsApiRequest waypoints(String... waypoints) {

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -20,7 +20,7 @@ import org.joda.time.DateTime;
 /**
  * A component of a Directions API result.
  *
- * See <a href="https://developers.google.com/maps/documentation/directions/#Legs">the Legs
+ * See <a href="https://developers.google.com/maps/documentation/directions/intro#Legs">the Legs
  * documentation</a> for more detail.
  */
 public class DirectionsLeg {

--- a/src/main/java/com/google/maps/model/DirectionsRoute.java
+++ b/src/main/java/com/google/maps/model/DirectionsRoute.java
@@ -20,7 +20,7 @@ package com.google.maps.model;
  * array. Even if the service returns no results (such as if the origin and/or destination doesn't
  * exist) it still returns an empty routes array.
  *
- * <p>Please see <a href="https://developers.google.com/maps/documentation/directions/#Routes">
+ * <p>Please see <a href="https://developers.google.com/maps/documentation/directions/intro#Routes">
  * Routes</a> for more detail.
  */
 public class DirectionsRoute {

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -25,7 +25,7 @@ package com.google.maps.model;
  * miles/40 minutes from this step.
  *
  * <p>When using the Directions API to search for transit directions, the steps array will include
- * additional <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+ * additional <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
  * Transit Details</a> in the form of a {@code transitDetails} array. If the directions include
  * multiple modes of transportation, detailed directions will be provided for walking or driving
  * steps in a {@code steps} array. For example, a walking step will include directions from the
@@ -80,14 +80,14 @@ public class DirectionsStep {
   public EncodedPolyline polyline;
 
   /**
-   * {@code travelMode} is the travel mode of this step. See <a href="https://developers.google.com/maps/documentation/directions/#TravelModes">Travel
+   * {@code travelMode} is the travel mode of this step. See <a href="https://developers.google.com/maps/documentation/directions/intro#TravelModes">Travel
    * Modes</a> for more detail.
    */
   public TravelMode travelMode;
 
   /**
    * {@code transitDetails} contains transit specific information. This field is only returned with
-   * travel_mode is set to "transit". See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+   * travel_mode is set to "transit". See <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
    * Transit Details</a> for more detail.
    */
   public TransitDetails transitDetails;

--- a/src/main/java/com/google/maps/model/Fare.java
+++ b/src/main/java/com/google/maps/model/Fare.java
@@ -21,7 +21,7 @@ import java.util.Currency;
 /**
  * A representation of ticket cost for use on public transit.
  *
- * See <a href="https://developers.google.com/maps/documentation/directions/#Routes">the Routes
+ * See <a href="https://developers.google.com/maps/documentation/directions/intro#Routes">the Routes
  * Documentation</a> for more detail.
  */
 public class Fare {

--- a/src/main/java/com/google/maps/model/StopDetails.java
+++ b/src/main/java/com/google/maps/model/StopDetails.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 /**
  * The stop/station.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
  * Transit details</a> for more detail.
  */
 public class StopDetails {

--- a/src/main/java/com/google/maps/model/TransitAgency.java
+++ b/src/main/java/com/google/maps/model/TransitAgency.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 /**
  * The operator of a line.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
  * Transit details</a> for more detail.
  */
 public class TransitAgency {

--- a/src/main/java/com/google/maps/model/TransitLine.java
+++ b/src/main/java/com/google/maps/model/TransitLine.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 /**
  * The transit line used in a step.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
  * Transit details</a> for more detail.
  */
 public class TransitLine {

--- a/src/main/java/com/google/maps/model/TravelMode.java
+++ b/src/main/java/com/google/maps/model/TravelMode.java
@@ -23,7 +23,7 @@ import java.util.Locale;
  * You may specify the transportation mode to use for calulating directions. Directions are
  * calculating as driving directions by default.
  *
- * @see <a href="https://developers.google.com/maps/documentation/directions/#TravelModes">
+ * @see <a href="https://developers.google.com/maps/documentation/directions/intro#TravelModes">
  * Directions API travel modes</a>
  * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#RequestParameters">
  * Distance Matrix API travel modes</a>

--- a/src/main/java/com/google/maps/model/Vehicle.java
+++ b/src/main/java/com/google/maps/model/Vehicle.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 /**
  * The vehicle used on a line.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/#TransitDetails">
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">
  * Transit details</a> for more detail.
  */
 public class Vehicle {

--- a/src/main/java/com/google/maps/model/VehicleType.java
+++ b/src/main/java/com/google/maps/model/VehicleType.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 /**
  * The vehicle types.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/#VehicleType">
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#VehicleType">
  * Vehicle Type</a> for more detail.
  */
 public enum VehicleType {


### PR DESCRIPTION
Links to the Directions API were missing "intro", and therefore were linking to a generic page rather than the specific documentation page.