### PR TITLE
Changing internal ExecutorService to use newWorkStealingPool

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,7 +11,7 @@ Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady
 Dave Holmes <daveholmes@google.com> @dh--
-Ismael Blesa <isma.work@gmail.com> @isblesa
+Ismael Blesa <isma.work@gmail.com> @ismamai
 Malcolm Windsor <malcolm@beoped.com> @mwindsor-beoped
 Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady
 Dave Holmes <daveholmes@google.com> @dh--
+Ismael Blesa <isma.work@gmail.com> @isblesa
 Malcolm Windsor <malcolm@beoped.com> @mwindsor-beoped
 Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier

--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -40,9 +40,6 @@ public class RateLimitExecutorService implements ExecutorService, Runnable {
   private static final int SECOND = 1000;
   private static final int HALF_SECOND = SECOND / 2;
 
-  // It's important we set Ok's second arg to threadFactory(.., true) to ensure the threads are
-  // killed when the app exits. For synchronous requests this is ideal but it means any async
-  // requests still pending after termination will be killed.
   private final ExecutorService delegate = Executors.newWorkStealingPool();
 
   private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();


### PR DESCRIPTION
This one will grow and shrink based on the number of operations. By default it builds as many threads as current available cores. This is introduced in java 8.

If we do not want to increase library to use java 8, we could use ThreadPoolExecutor initialized to the number of current available cores.

Another issue is that it does not take a ThreadFactory as argument and we lose the possibility to name the threads and set them as daemons.
