### PR TITLE
Keep using ThreadPoolExecutor but increase number of threads

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,7 +11,7 @@ Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady
 Dave Holmes <daveholmes@google.com> @dh--
-Ismael Blesa <isma.work@gmail.com> @isblesa
+Ismael Blesa <isma.work@gmail.com> @ismamai
 Malcolm Windsor <malcolm@beoped.com> @mwindsor-beoped
 Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady
 Dave Holmes <daveholmes@google.com> @dh--
+Ismael Blesa <isma.work@gmail.com> @isblesa
 Malcolm Windsor <malcolm@beoped.com> @mwindsor-beoped
 Mark McDonald <macd@google.com> @markmcd
 Nicolas Poirier <dev.nicolaspoirier@gmail.com> @NicolasPoirier

--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -44,7 +44,7 @@ public class RateLimitExecutorService implements ExecutorService, Runnable {
   // It's important we set Ok's second arg to threadFactory(.., true) to ensure the threads are
   // killed when the app exits. For synchronous requests this is ideal but it means any async
   // requests still pending after termination will be killed.
-  private final ExecutorService delegate = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60,
+  private final ExecutorService delegate = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), Integer.MAX_VALUE, 60,
       TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
       threadFactory("Rate Limited Dispatcher", true));
 


### PR DESCRIPTION
Instead of using the newWorkStealingPool we can change ThreadPoolExecutor to create as many threads as current available cores. This will allow many threads to execute calls. The problem is that it does not seem to grow/shrink based on the number of operations