### PR TITLE
Add waypoints method that takes in an array of LatLng

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -168,6 +168,21 @@ public class DirectionsApiRequest
   }
 
   /**
+   * The list of waypoints as latitude,longitude locations.
+   */
+  public DirectionsApiRequest waypoints(LatLng... waypoints) {
+    if (waypoints == null) {
+      return this;
+    }
+    int length = waypoints.length;
+    String[] waypointStrings = new String[length];
+    for (int i = 0; i < length; i++) {
+      waypointStrings[i] = waypoints[i].toString();
+    }
+    return waypoints(waypointStrings);
+  }
+
+  /**
    * Allow the Directions service to optimize the provided route by rearranging the waypoints in a
    * more efficient order.
    */

--- a/src/test/java/com/google/maps/DirectionsApiTest.java
+++ b/src/test/java/com/google/maps/DirectionsApiTest.java
@@ -20,6 +20,7 @@ import com.google.maps.errors.NotFoundException;
 import com.google.maps.model.AddressType;
 import com.google.maps.model.DirectionsResult;
 import com.google.maps.model.GeocodedWaypointStatus;
+import com.google.maps.model.LatLng;
 import com.google.maps.model.TrafficModel;
 import com.google.maps.model.TransitMode;
 import com.google.maps.model.TransitRoutingPreference;
@@ -157,7 +158,7 @@ public class DirectionsApiTest extends AuthenticatedTest {
   /**
    * Boston to Concord, via Charlestown and Lexington.
    *
-   * {@code http://maps.googleapis.com/maps/api/directions/json?origin=Boston,MA&destination=Concord,MA&waypoints=Charlestown,MA|Lexington,MA
+   * {@code http://maps.googleapis.com/maps/api/directions/json?origin=Boston,MA&destination=Concord,MA&waypoints=Charlestown,MA|Lexington,MA}
    */
   @Test
   public void testBostonToConcordViaCharlestownAndLexignton() throws Exception {
@@ -165,6 +166,22 @@ public class DirectionsApiTest extends AuthenticatedTest {
         .origin("Boston,MA")
         .destination("Concord,MA")
         .waypoints("Charlestown,MA", "Lexington,MA")
+        .await();
+
+    assertNotNull(result.routes);
+  }
+
+  /**
+   * Boston to Concord, via Charlestown and Lexington, but using exact latitude and longitude coordinates for the waypoints.
+   *
+   * {@code http://maps.googleapis.com/maps/api/directions/json?origin=Boston,MA&destination=Concord,MA&waypoints=42.379322,-71.063384|42.444303,-71.229087}
+   */
+  @Test
+  public void testBostonToConcordViaCharlestownAndLexigntonLatLng() throws Exception {
+    DirectionsResult result = DirectionsApi.newRequest(context)
+        .origin("Boston,MA")
+        .destination("Concord,MA")
+        .waypoints(new LatLng(42.379322, -71.063384), new LatLng(42.444303, -71.229087))
         .await();
 
     assertNotNull(result.routes);


### PR DESCRIPTION
The origin and destination methods have two versions, one that takes a String and one that takes a LatLng. This commit adds a second method for the waypoints method that takes in a LatLng array.