### PR TITLE
Update NearbySearchRequest.java

### DIFF
--- a/src/main/java/com/google/maps/NearbySearchRequest.java
+++ b/src/main/java/com/google/maps/NearbySearchRequest.java
@@ -155,7 +155,7 @@ public class NearbySearchRequest
     }
   }
 
-  public class Response implements ApiResponse<PlacesSearchResponse> {
+  public static class Response implements ApiResponse<PlacesSearchResponse> {
 
     public String status;
     public String htmlAttributions[];


### PR DESCRIPTION
Solution for issue #242 

Unable to invoke no-args constructor for class com.google.maps.NearbySearchRequest$Response. Register an InstanceCreator with Gson for this type may fix this problem.

This issue can be solved by making `NearbySearchRequest$Response` class static
Please note that all other subclasses of ApiResponse are static as well.