### PR TITLE
Fixing concurrency problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build/
 .gradle/
 *.iml
 .idea/
+/bin/
+.settings/
+.project
+.classpath

--- a/src/main/java/com/google/maps/internal/UrlSigner.java
+++ b/src/main/java/com/google/maps/internal/UrlSigner.java
@@ -52,7 +52,17 @@ public class UrlSigner {
    * Generate url safe HmacSHA1 of a path.
    */
   public String getSignature(String path) {
-    byte[] digest = mac.doFinal(path.getBytes());
+    byte[] digest = getMac().doFinal(path.getBytes());
     return ByteString.of(digest).base64().replace('+', '-').replace('/', '_');
   }
+
+  private Mac getMac() {
+    // Mac is not thread-safe. Requires a new clone for each signature.
+    try {
+      return (Mac) mac.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
 }

--- a/src/test/java/com/google/maps/internal/UrlSignerTest.java
+++ b/src/test/java/com/google/maps/internal/UrlSignerTest.java
@@ -66,11 +66,15 @@ public class UrlSignerTest {
       executor.execute(new Runnable() {
         @Override
         public void run() {
-          if (!SIGNATURE.equals(urlSigner.getSignature(MESSAGE))) {
+          try {
+            if (!SIGNATURE.equals(urlSigner.getSignature(MESSAGE))) {
+              fails.add(true);
+            }
+          } catch(Exception e) {
             fails.add(true);
           }
         }
-	  });
+      });
     }
 
     executor.shutdown();

--- a/src/test/java/com/google/maps/internal/UrlSignerTest.java
+++ b/src/test/java/com/google/maps/internal/UrlSignerTest.java
@@ -16,11 +16,19 @@
 package com.google.maps.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import com.google.maps.SmallTests;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import com.google.maps.SmallTests;
 
 import okio.ByteString;
 
@@ -44,6 +52,31 @@ public class UrlSignerTest {
   public void testUrlSigner() throws Exception {
     UrlSigner urlSigner = new UrlSigner(SIGNING_KEY);
     assertEquals(SIGNATURE, urlSigner.getSignature(MESSAGE));
+  }
+  
+  @Test
+  public void testMustSupportParallelSignatures() throws Exception {
+    int attempts = 100;
+    ExecutorService executor = Executors.newFixedThreadPool(attempts);
+
+    final UrlSigner urlSigner = new UrlSigner(SIGNING_KEY);
+    final List<Boolean> fails = Collections.synchronizedList(new ArrayList<Boolean>());
+
+    for (int i = 0; i < attempts; i++) {
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          if (!SIGNATURE.equals(urlSigner.getSignature(MESSAGE))) {
+            fails.add(true);
+          }
+        }
+	  });
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(20, TimeUnit.SECONDS);
+
+    assertTrue(fails.isEmpty());
   }
 
   // Helper code from http://stackoverflow.com/questions/140131/


### PR DESCRIPTION
Fixes #254.

I decided to use the clone strategy to maintain compatibility with the current exception handling for `NoSuchAlgorithmException` and `InvalidKeyException` on `UrlSigner` creation.