### PR TITLE
Solving performance problems in parallel processing

### DIFF
--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -42,10 +42,12 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
   private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   private final OkHttpClient client = new OkHttpClient();
   private final RateLimitExecutorService rateLimitExecutorService;
+  private final Dispatcher dispatcher;
 
   public OkHttpRequestHandler() {
     rateLimitExecutorService = new RateLimitExecutorService();
-    client.setDispatcher(new Dispatcher(rateLimitExecutorService));
+    dispatcher = new Dispatcher(rateLimitExecutorService);
+    client.setDispatcher(dispatcher);
   }
 
   @Override
@@ -95,11 +97,15 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
   @Override
   public void setQueriesPerSecond(int maxQps) {
+    dispatcher.setMaxRequests(maxQps);
+    dispatcher.setMaxRequestsPerHost(maxQps);
     rateLimitExecutorService.setQueriesPerSecond(maxQps);
   }
 
   @Override
   public void setQueriesPerSecond(int maxQps, int minimumInterval) {
+    dispatcher.setMaxRequests(maxQps);
+    dispatcher.setMaxRequestsPerHost(maxQps);
     rateLimitExecutorService.setQueriesPerSecond(maxQps, minimumInterval);
   }
 

--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +48,7 @@ public class RateLimitExecutorService implements ExecutorService, Runnable {
   // killed when the app exits. For synchronous requests this is ideal but it means any async
   // requests still pending after termination will be killed.
   private final ExecutorService delegate = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), Integer.MAX_VALUE, 60,
-      TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
+      TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
       threadFactory("Rate Limited Dispatcher", true));
 
   private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();


### PR DESCRIPTION
Hi.

In this patch, I first adjusted the problem described in issue #256.

But even after this, I did some testing and the parallel performance was still much lower than expected (set in GeoApiContextProvider.setQueryRateLimit)

After a few more tests, I identified that the problem was in the delay between [take operations in RateLimitExecutorService](https://github.com/googlemaps/google-maps-services-java/blob/master/src/main/java/com/google/maps/internal/RateLimitExecutorService.java#L90).

The [ThreadPoolExecutor documentation](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html), explains the overhead of using the LinkedBlockingQueue as workQueue and suggests the use of SynchronousQueue as a good choice.

To my surprise, when I tested only this change I had incredible results.

I used the example cited by @irineuruiz in #228 with litle changes to perform the test with 500 tries and 50 QPS.

Using LinkedBlockingQueue:
Time taken: 22248
QPS achieved: 22.473930240920534

Using SynchronousQueue:
Time taken: 11467
QPS achieved: 43.60338362256911

Also, I checked that by default the [OkHttp Dispatcher](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Dispatcher.java#L65) uses SynchronousQueue to run.  So I think it's a pretty safe change.

This patch fixes #256 and #228 issues and will allows us to achiev the expected QPS.