### PR TITLE
Update documentation publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,16 @@ req.setCallback(new PendingResult.Callback<GeocodingResult[]>() {
     $ ./gradlew javadoc
 
     # Publish documentation
+    $ git checkout $VERSION
     $ ./gradlew javadoc
     $ git checkout gh-pages
-    $ rm -rf javadoc
     $ mkdir $VERSION
     $ mv build/docs/javadoc $VERSION
     $ git add $VERSION/javadoc
+    $ rm latest
+    $ ln -s $VERSION latest
     $ git add latest
-    $ git commit
+    $ git commit -m "Javadoc for $VERSION"
     $ git push origin gh-pages
 
 [apikey]: https://developers.google.com/maps/faq#keysystem


### PR DESCRIPTION
The documentation publishing instructions look a little out of date. This is a suggestion on fixing them up.

This changes:
* Removes reference to nonexistent `javadoc` directory. Maybe this is a leftover from an older build process?
* Checks out the version tag before building the javadoc, to make sure they're getting exactly that version, and no subsequent changes on master.
* Includes steps to update the `latest` symlink.
* Includes a commit comment that matches the format I saw in the `gh-pages` branch history.