### PR TITLE
Spell 'adapter' consistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .project
 .classpath
 .vscode/
+/.nb-gradle/

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For even more information, see the guide to [API keys][apikey].
 You can add the library to your project via Maven or Gradle.
 
 **Note:** Since 0.1.18 there is now a dependency on [SLF4J](https://www.slf4j.org/). You need to add
-one of the adaptor dependencies that makes sense for your logging setup. In the configuration 
+one of the adapter dependencies that makes sense for your logging setup. In the configuration 
 samples below we are integrating 
 [slf4j-nop](https://search.maven.org/#artifactdetails%7Corg.slf4j%7Cslf4j-nop%7C1.7.25%7Cjar),
 but there are others like 

--- a/src/main/java/com/google/maps/internal/DayOfWeekAdapter.java
+++ b/src/main/java/com/google/maps/internal/DayOfWeekAdapter.java
@@ -19,48 +19,52 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import com.google.maps.model.PriceLevel;
+import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
 import java.io.IOException;
 
 /**
- * This class handles conversion from JSON to {@link PriceLevel}.
+ * This class handles conversion from JSON to {@link DayOfWeek}.
  *
  * <p>Please see <a
  * href="https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/TypeAdapter.html">GSON
  * Type Adapter</a> for more detail.
  */
-public class PriceLevelAdaptor extends TypeAdapter<PriceLevel> {
+public class DayOfWeekAdapter extends TypeAdapter<DayOfWeek> {
 
   @Override
-  public PriceLevel read(JsonReader reader) throws IOException {
+  public DayOfWeek read(JsonReader reader) throws IOException {
     if (reader.peek() == JsonToken.NULL) {
       reader.nextNull();
       return null;
     }
 
     if (reader.peek() == JsonToken.NUMBER) {
-      int priceLevel = reader.nextInt();
+      int day = reader.nextInt();
 
-      switch (priceLevel) {
+      switch (day) {
         case 0:
-          return PriceLevel.FREE;
+          return DayOfWeek.SUNDAY;
         case 1:
-          return PriceLevel.INEXPENSIVE;
+          return DayOfWeek.MONDAY;
         case 2:
-          return PriceLevel.MODERATE;
+          return DayOfWeek.TUESDAY;
         case 3:
-          return PriceLevel.EXPENSIVE;
+          return DayOfWeek.WEDNESDAY;
         case 4:
-          return PriceLevel.VERY_EXPENSIVE;
+          return DayOfWeek.THURSDAY;
+        case 5:
+          return DayOfWeek.FRIDAY;
+        case 6:
+          return DayOfWeek.SATURDAY;
       }
     }
 
-    return PriceLevel.UNKNOWN;
+    return DayOfWeek.UNKNOWN;
   }
 
   /** This method is not implemented. */
   @Override
-  public void write(JsonWriter writer, PriceLevel value) throws IOException {
+  public void write(JsonWriter writer, DayOfWeek value) throws IOException {
     throw new UnsupportedOperationException("Unimplemented method");
   }
 }

--- a/src/main/java/com/google/maps/internal/GaePendingResult.java
+++ b/src/main/java/com/google/maps/internal/GaePendingResult.java
@@ -187,8 +187,8 @@ public class GaePendingResult<T, R extends ApiResponse<T>> implements PendingRes
                 LocationType.class, new SafeEnumAdapter<LocationType>(LocationType.UNKNOWN))
             .registerTypeAdapter(
                 RatingType.class, new SafeEnumAdapter<RatingType>(RatingType.UNKNOWN))
-            .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdaptor())
-            .registerTypeAdapter(PriceLevel.class, new PriceLevelAdaptor())
+            .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdapter())
+            .registerTypeAdapter(PriceLevel.class, new PriceLevelAdapter())
             .registerTypeAdapter(Instant.class, new InstantAdapter())
             .registerTypeAdapter(LocalTime.class, new LocalTimeAdapter())
             .registerTypeAdapter(GeolocationApi.Response.class, new GeolocationResponseAdapter())

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -254,8 +254,8 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
                 LocationType.class, new SafeEnumAdapter<LocationType>(LocationType.UNKNOWN))
             .registerTypeAdapter(
                 RatingType.class, new SafeEnumAdapter<RatingType>(RatingType.UNKNOWN))
-            .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdaptor())
-            .registerTypeAdapter(PriceLevel.class, new PriceLevelAdaptor())
+            .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdapter())
+            .registerTypeAdapter(PriceLevel.class, new PriceLevelAdapter())
             .registerTypeAdapter(Instant.class, new InstantAdapter())
             .registerTypeAdapter(LocalTime.class, new LocalTimeAdapter())
             .registerTypeAdapter(GeolocationApi.Response.class, new GeolocationResponseAdapter())

--- a/src/main/java/com/google/maps/internal/PriceLevelAdapter.java
+++ b/src/main/java/com/google/maps/internal/PriceLevelAdapter.java
@@ -19,52 +19,48 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import com.google.maps.model.OpeningHours.Period.OpenClose.DayOfWeek;
+import com.google.maps.model.PriceLevel;
 import java.io.IOException;
 
 /**
- * This class handles conversion from JSON to {@link DayOfWeek}.
+ * This class handles conversion from JSON to {@link PriceLevel}.
  *
  * <p>Please see <a
  * href="https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/TypeAdapter.html">GSON
  * Type Adapter</a> for more detail.
  */
-public class DayOfWeekAdaptor extends TypeAdapter<DayOfWeek> {
+public class PriceLevelAdapter extends TypeAdapter<PriceLevel> {
 
   @Override
-  public DayOfWeek read(JsonReader reader) throws IOException {
+  public PriceLevel read(JsonReader reader) throws IOException {
     if (reader.peek() == JsonToken.NULL) {
       reader.nextNull();
       return null;
     }
 
     if (reader.peek() == JsonToken.NUMBER) {
-      int day = reader.nextInt();
+      int priceLevel = reader.nextInt();
 
-      switch (day) {
+      switch (priceLevel) {
         case 0:
-          return DayOfWeek.SUNDAY;
+          return PriceLevel.FREE;
         case 1:
-          return DayOfWeek.MONDAY;
+          return PriceLevel.INEXPENSIVE;
         case 2:
-          return DayOfWeek.TUESDAY;
+          return PriceLevel.MODERATE;
         case 3:
-          return DayOfWeek.WEDNESDAY;
+          return PriceLevel.EXPENSIVE;
         case 4:
-          return DayOfWeek.THURSDAY;
-        case 5:
-          return DayOfWeek.FRIDAY;
-        case 6:
-          return DayOfWeek.SATURDAY;
+          return PriceLevel.VERY_EXPENSIVE;
       }
     }
 
-    return DayOfWeek.UNKNOWN;
+    return PriceLevel.UNKNOWN;
   }
 
   /** This method is not implemented. */
   @Override
-  public void write(JsonWriter writer, DayOfWeek value) throws IOException {
+  public void write(JsonWriter writer, PriceLevel value) throws IOException {
     throw new UnsupportedOperationException("Unimplemented method");
   }
 }


### PR DESCRIPTION
This project uses a mix of the spellings "adapter" and "adaptor". I assume that is just a typographical quirk, not an intentional distinction. This PR cleans it up by changing everything to "adapter".

I chose "adapter" over "adaptor" because it's the predominant spelling in this project.

```
[~/local/repos/google-maps-services-java on ⇄ master]
$ grep -ri adapter * | wc -l
     182
[~/local/repos/google-maps-services-java on ⇄ master]
$ grep -ri adaptor * | wc -l
       7
```

Google n-grams agrees for general usage:

<img width="898" alt="ngram - adapter vs adaptor - 2017-07-27" src="https://user-images.githubusercontent.com/2618447/28698837-f9d4ac2e-7313-11e7-90c4-00d0d79cff30.png">


This spelling change includes renaming a couple classes, but they're in the `internal` package, so that shouldn't cause any breakage. (Unless clients are intentionally using `internal` classes, which I assume is unsupported.) 

After this change, the build succeeds and the tests pass for me locally, building with JDK 1.8.0_144-b01 on macOS 10.12.6.