### PR TITLE
Add .nb-gradle files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 /bin/
 /com/
 .gradle/
+.nb-gradle/
+.nb-gradle-properties
 *.iml
 .idea/
 .settings/
 .project
 .classpath
 .vscode/
-/.nb-gradle/


### PR DESCRIPTION
This is for users of NetBeans with its Gradle plugin, which drops `.nb-gradle` and `.nb-gradle-properties` as part of its build process. It's a local build file like `.build`, so it shouldn't get checked in to the repo. This change keeps local repos appearing "clean" for NetBeans users, and prevents clutter from accidentally getting checked in.

This also adds a newline at the end of `.gitignore`, which was missing before. That change doesn't matter; it just happened as a side effect of saving the file from `vi` or Sublime Text. Should probably keep it since that's the default behavior for many editors.