### PR TITLE
README: Make central repo links do searches for this lib 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ contribute, please read [How to Contribute][contrib].
 
 Each Google Maps Web Service request requires an API key or client ID. API keys
 are freely available with a Google Account at
-https://developers.google.com/console. The type of API key you need is a 
-**Server key**. 
+https://developers.google.com/console. The type of API key you need is a
+**Server key**.
 
 To get an API key:
 
@@ -72,8 +72,8 @@ To get an API key:
     * Time Zone API
  1. Create a new **Server key**.
  1. If you'd like to restrict requests to a specific IP address, do so now.
- 
-For guided help, follow the instructions for the [Directions API][directions-key]. 
+
+For guided help, follow the instructions for the [Directions API][directions-key].
 You only need one API key, but remember to enable all the APIs you need.
 For even more information, see the guide to [API keys][apikey].
 
@@ -87,7 +87,7 @@ You can add the library to your project via Maven or Gradle.
 one of the adapter dependencies that makes sense for your logging setup. In the configuration 
 samples below we are integrating 
 [slf4j-nop](https://search.maven.org/#artifactdetails%7Corg.slf4j%7Cslf4j-nop%7C1.7.25%7Cjar),
-but there are others like 
+but there are others like
 [slf4j-log4j12](https://search.maven.org/#artifactdetails%7Corg.slf4j%7Cslf4j-log4j12%7C1.7.25%7Cjar)
 and [slf4j-jdk14](https://search.maven.org/#artifactdetails%7Corg.slf4j%7Cslf4j-jdk14%7C1.7.25%7Cjar)
 that will make more sense in other configurations. This will stop a warning message being emitted
@@ -119,8 +119,8 @@ dependencies {
 }
 ```
 
-You can find the latest version at the top of this README or by searching
-[Maven Central](https://search.maven.org/) or [Gradle, Please](http://gradleplease.appspot.com/).
+You can find the latest version at the top of this README or by [searching
+Maven Central](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22google-maps-services%22) or [Gradle, Please](http://gradleplease.appspot.com/#google-maps-services).
 
 ## Developer Documentation
 


### PR DESCRIPTION
Maybe the "search" links to Maven Central Repo and Gradle, Please in the README should go to searches for this library, instead of just the home pages?

This PR turns those home page links into links specifically to searches for google-maps-services on those repos. Seems like this would be more convenient for library users.

This PR also picked up some extraneous whitespace-stripping changes due to my Atom editor settings. Sorry about that.