### PR TITLE
Upgrade mockwebserver to 3.8.1 from OkHttp distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.google.mockwebserver:mockwebserver:20130706'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.3'
     testCompile 'org.slf4j:slf4j-simple:1.7.25'
     testCompile 'commons-lang:commons-lang:2.6'

--- a/src/test/java/com/google/maps/LocalTestServerContext.java
+++ b/src/test/java/com/google/maps/LocalTestServerContext.java
@@ -18,14 +18,15 @@ package com.google.maps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.mockwebserver.MockResponse;
-import com.google.mockwebserver.MockWebServer;
-import com.google.mockwebserver.RecordedRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.json.JSONObject;
@@ -43,7 +44,7 @@ public class LocalTestServerContext implements AutoCloseable {
     MockResponse response = new MockResponse();
     response.setBody(responseBody);
     server.enqueue(response);
-    server.play();
+    server.start();
 
     this.context =
         new GeoApiContext.Builder()
@@ -67,7 +68,8 @@ public class LocalTestServerContext implements AutoCloseable {
 
   public JSONObject requestBody() throws InterruptedException {
     this.takeRequest();
-    return new JSONObject(new String(request.getBody(), Charset.forName("UTF8")));
+    
+    return new JSONObject(request.getBody().readUtf8());
   }
 
   private List<NameValuePair> actualParams() throws InterruptedException, URISyntaxException {


### PR DESCRIPTION
This library uses an old version of `mockwebserver` from back when it was a standalone project. It has since been folded in to OkHttp, which this project also uses. The new `mockwebserver` is at `com.squareup.okhttp3:mockwebserver:3.8.1`.

From their [old Google Code website](https://code.google.com/archive/p/mockwebserver/):

<img width="477" alt="screen shot 2017-07-28 at 6 34 19 pm" src="https://user-images.githubusercontent.com/2618447/28739353-53a86650-73c8-11e7-9878-da322b12fd67.png">


Shall we upgrade to the new version from OkHttp? It looks like this project is keeping current on all its other dependencies.

This PR accomplishes the upgrade by changing the `mockwebserver` dependency to the new `com.squareup.okhttp3:mockwebserver:3.8.1` one, and updating the code to handle the `mockwebserver` API changes between 20130706 and 3.8.1.

Tests pass locally for me.