### PR TITLE
Suppress deprecation warnings for radarSearchQuery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,14 @@ task updateVersion(type: Copy) {
 compileJava.source = "build/filtered/src/main/java"
 compileJava.dependsOn updateVersion
 
+compileJava {
+    options.compilerArgs << "-Xlint:deprecation"
+}
+
+compileTestJava {
+    options.compilerArgs << "-Xlint:deprecation"
+}
+
 // Propagate API Key system properties to test tasks
 tasks.withType(Test) {
     systemProperty 'api.key', System.getProperty('api.key')

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -581,6 +581,7 @@ public class PlacesApiTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // radarSearchQuery still supported until 6/30/2018
   public void testRadarSearchRequest() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext("{\"status\" : \"OK\"}")) {
       LatLng location = new LatLng(10, 20);
@@ -607,6 +608,7 @@ public class PlacesApiTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  @SuppressWarnings("deprecation") // radarSearchQuery still supported until 6/30/2018
   public void testRadarSearchLocationWithoutKeywordNameOrType() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext("")) {
       LatLng location = new LatLng(10, 20);
@@ -746,6 +748,7 @@ public class PlacesApiTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // radarSearchQuery still supported until 6/30/2018
   public void testRadarSearchRequestByKeyword() throws Exception {
     try (LocalTestServerContext sc =
         new LocalTestServerContext(placesApiRadarSearchRequestByKeyword)) {
@@ -761,6 +764,7 @@ public class PlacesApiTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // radarSearchQuery still supported until 6/30/2018
   public void testRadarSearchRequestByName() throws Exception {
     try (LocalTestServerContext sc =
         new LocalTestServerContext(placesApiRadarSearchRequestByName)) {
@@ -779,6 +783,7 @@ public class PlacesApiTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // radarSearchQuery still supported until 6/30/2018
   public void testRadarSearchRequestByType() throws Exception {
     try (LocalTestServerContext sc =
         new LocalTestServerContext(placesApiRadarSearchRequestByType)) {


### PR DESCRIPTION
When I run `./gradlew test`, there are deprecation warnings because `PlacesApiTest` calls `PlacesApi.radarSearchQuery`, which is deprecated.

When I enable verbose `-Xlint:deprecated`, I get this.

```
> Task :compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/GeoApiContextTest.java:79: warning: [unchecked] unchecked method invocation: method get in class GeoApiContext is applied to given types
    builder.build().get(new ApiConfig(path), fakeResponse.getClass(), params).awaitIgnoreError();
                       ^
  required: ApiConfig,Class<? extends R>,Map<String,String>
  found: ApiConfig,Class<CAP#1>,Map<String,String>
  where R,T are type-variables:
    R extends ApiResponse<T> declared in method <T,R>get(ApiConfig,Class<? extends R>,Map<String,String>)
    T extends Object declared in method <T,R>get(ApiConfig,Class<? extends R>,Map<String,String>)
  where CAP#1 is a fresh type-variable:
    CAP#1 extends ApiResponse from capture of ? extends ApiResponse
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java:587: warning: [deprecation] radarSearchQuery(GeoApiContext,LatLng,int) in PlacesApi has been deprecated
      PlacesApi.radarSearchQuery(sc.context, location, 5000)
               ^
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java:613: warning: [deprecation] radarSearchQuery(GeoApiContext,LatLng,int) in PlacesApi has been deprecated
      PlacesApi.radarSearchQuery(sc.context, location, 5000).await();
               ^
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java:753: warning: [deprecation] radarSearchQuery(GeoApiContext,LatLng,int) in PlacesApi has been deprecated
          PlacesApi.radarSearchQuery(sc.context, SYDNEY, 10000).keyword("pub").await();
                   ^
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java:768: warning: [deprecation] radarSearchQuery(GeoApiContext,LatLng,int) in PlacesApi has been deprecated
          PlacesApi.radarSearchQuery(sc.context, SYDNEY, 10000).name("Sydney Town Hall").await();
                   ^
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java:786: warning: [deprecation] radarSearchQuery(GeoApiContext,LatLng,int) in PlacesApi has been deprecated
          PlacesApi.radarSearchQuery(sc.context, SYDNEY, 10000).type(PlaceType.BAR).await();
```

Because this is commented as still working until June 2018, I assume that it's intentional to keep the tests for it in place until the feature is actually turned off and it is removed from the google-maps-services-java API.

This PR suppresses those deprecation warnings, leaving the tests in place. This results in cleaner output for developers running the tests.

This PR also enables verbose output for deprecation warnings to make diagnosing them easier. I think this is a good idea because aside from the `radarSearchQuery` warnings, which are now handled in this PR, there are no deprecation warnings, so it won't end up spamming people who run the build. And IMHO this is the right approach to use for tracking down deprecated method calls and either fixing them up or putting warning suppressions on them.