### PR TITLE
Update GeoApiContext.java - Exception using GAE

### DIFF
--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -291,6 +291,10 @@ public class GeoApiContext {
     public Builder() {
       requestHandlerBuilder(new OkHttpRequestHandler.Builder());
     }
+    
+    public Builder(RequestHandler.Builder builder) {
+      requestHandlerBuilder(builder);
+    }
 
     /**
      * Change the RequestHandler.Builder strategy to change between the {@code OkHttpRequestHandler}


### PR DESCRIPTION
Fixed GeoApiContext class, because of exception NoClassDefFoundError when using GAE(due of Builder initializing OkHttpRequestHandler). Created another constructor that receives RequestHandler.Builder as workaround.