### PR TITLE
Update build.gradle - Changed guava to v20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile 'joda-time:joda-time:2.9.9'
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.54'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'com.google.guava:guava:22.0'
+    compile 'com.google.guava:guava:20.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
com.google.guava:guava v22 require JDK 8, changing to guava v20 makes it compatible with JDK 7+.