### PR TITLE
README: Point "javadoc" link at the new v0.2.1 javadocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Maven Central](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22google-maps-se
 
 ## Developer Documentation
 
-View the [javadoc](https://googlemaps.github.io/google-maps-services-java/v0.1.21/javadoc/).
+View the [javadoc](https://googlemaps.github.io/google-maps-services-java/v0.2.1/javadoc/).
 
 Additional documentation for the included web services is available at
 https://developers.google.com/maps/.


### PR DESCRIPTION
Updates the "javadoc" link in the README to point at the latest v0.2.1 javadocs.

Depends on https://github.com/googlemaps/google-maps-services-java/pull/310, which actually publishes those v0.2.1 javadocs.