### PR TITLE
Javadoc: Update links and fix typos

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -30,8 +30,8 @@ import com.google.maps.model.GeocodedWaypoint;
  * text strings (e.g. "Chicago, IL" or "Darwin, NT, Australia") or as latitude/longitude
  * coordinates. The Directions API can return multi-part directions using a series of waypoints.
  *
- * <p>See <a
- * href="https://developers.google.com/maps/documentation/directions/intro">documentation</a>.
+ * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro">the Directions
+ * API Developer's Guide</a> for more information.
  */
 public class DirectionsApi {
   static final ApiConfig API_CONFIG = new ApiConfig("/maps/api/directions/json");
@@ -82,8 +82,9 @@ public class DirectionsApi {
    *
    * @see <a href="https://developers.google.com/maps/documentation/directions/intro#Restrictions">
    *     Restrictions in the Directions API</a>
-   * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#Restrictions">
-   *     Restrictions in the Distance Matrix API</a>
+   * @see <a
+   *     href="https://developers.google.com/maps/documentation/distance-matrix/intro#RequestParameters">
+   *     Distance Matrix API Request Parameters</a>
    */
   public enum RouteRestriction implements UrlValue {
 

--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -83,7 +83,7 @@ public class DirectionsApiRequest
   }
 
   /**
-   * The origin, as a latitude,longitude location.
+   * The origin, as a latitude/longitude location.
    *
    * @param origin The starting location for the Directions request.
    * @return Returns this {@code DirectionsApiRequest} for call chaining.
@@ -93,7 +93,7 @@ public class DirectionsApiRequest
   }
 
   /**
-   * The destination, as a latitude,longitude location.
+   * The destination, as a latitude/longitude location.
    *
    * @param destination The ending location for the Directions request.
    * @return Returns this {@code DirectionsApiRequest} for call chaining.

--- a/src/main/java/com/google/maps/DistanceMatrixApi.java
+++ b/src/main/java/com/google/maps/DistanceMatrixApi.java
@@ -28,16 +28,16 @@ import com.google.maps.model.DistanceMatrixRow;
  * duration and distance values for each pair.
  *
  * <p>This service does not return detailed route information. Route information can be obtained by
- * passing the desired single origin and destination to the Directions API, {@link
+ * passing the desired single origin and destination to the Directions API, using {@link
  * com.google.maps.DirectionsApi}.
  *
  * <p><strong>Note:</strong> Use of the Distance Matrix API must relate to the display of
  * information on a Google Map; for example, to determine origin-destination pairs that fall within
  * a specific driving time from one another, before requesting and displaying those destinations on
- * a map. Use of the service in an application that doesn't display a Google map is prohibited.
+ * a map. Use of the service in an application that doesn't display a Google Map is prohibited.
  *
  * @see <a href="https://developers.google.com/maps/documentation/distancematrix/">Distance Matrix
- *     Documentation</a>
+ *     API Documentation</a>
  */
 public class DistanceMatrixApi {
   static final ApiConfig API_CONFIG = new ApiConfig("/maps/api/distancematrix/json");

--- a/src/main/java/com/google/maps/DistanceMatrixApiRequest.java
+++ b/src/main/java/com/google/maps/DistanceMatrixApiRequest.java
@@ -53,9 +53,9 @@ public class DistanceMatrixApiRequest
 
   /**
    * One or more addresses from which to calculate distance and time. The service will geocode the
-   * string and convert it to a latitude/longitude coordinate to calculate directions.
+   * strings and convert them to latitude/longitude coordinates to calculate directions.
    *
-   * @param origins String to geocode and use as an origin point (e.g. "New York, NY")
+   * @param origins Strings to geocode and use as an origin point (e.g. "New York, NY")
    * @return Returns this {@code DistanceMatrixApiRequest} for call chaining.
    */
   public DistanceMatrixApiRequest origins(String... origins) {
@@ -74,9 +74,9 @@ public class DistanceMatrixApiRequest
 
   /**
    * One or more addresses to which to calculate distance and time. The service will geocode the
-   * string and convert it to a latitude/longitude coordinate to calculate directions.
+   * strings and convert them to latitude/longitude coordinates to calculate directions.
    *
-   * @param destinations String to geocode and use as a destination point (e.g. "New Jersey, NY")
+   * @param destinations Strings to geocode and use as a destination point (e.g. "Jersey City, NJ")
    * @return Returns this {@code DistanceMatrixApiRequest} for call chaining.
    */
   public DistanceMatrixApiRequest destinations(String... destinations) {
@@ -128,8 +128,9 @@ public class DistanceMatrixApiRequest
    * Specifies the unit system to use when expressing distance as text. Distance Matrix results
    * contain text within distance fields to indicate the distance of the calculated route.
    *
-   * @param unit One of {@link Unit#METRIC}, {@link Unit#IMPERIAL}.
-   * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#unit_systems">
+   * @param unit One of {@link Unit#METRIC} or {@link Unit#IMPERIAL}.
+   * @see <a
+   *     href="https://developers.google.com/maps/documentation/distance-matrix/intro#unit_systems">
    *     Unit systems in the Distance Matrix API</a>
    * @return Returns this {@code DistanceMatrixApiRequest} for call chaining.
    */
@@ -145,7 +146,7 @@ public class DistanceMatrixApiRequest
    * <ul>
    *   <li>For requests where the travel mode is transit: You can optionally specify one of
    *       departure_time or arrival_time. If neither time is specified, the departure_time defaults
-   *       to now (that is, the departure time defaults to the current time).
+   *       to now. (That is, the departure time defaults to the current time.)
    *   <li>For requests where the travel mode is driving: Google Maps API for Work customers can
    *       specify the departure_time to receive trip duration considering current traffic
    *       conditions. The departure_time must be set to within a few minutes of the current time.

--- a/src/main/java/com/google/maps/ElevationApi.java
+++ b/src/main/java/com/google/maps/ElevationApi.java
@@ -26,11 +26,12 @@ import com.google.maps.model.EncodedPolyline;
 import com.google.maps.model.LatLng;
 
 /**
- * The Google Elevation API provides you a simple interface to query locations on the earth for
+ * The Google Elevation API provides a simple interface to query locations on the earth for
  * elevation data. Additionally, you may request sampled elevation data along paths, allowing you to
  * calculate elevation changes along routes.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/elevation/">documentation</a>.
+ * <p>See <a href="https://developers.google.com/maps/documentation/elevation/start">the Google Maps
+ * Elevation API documentation</a>.
  */
 public class ElevationApi {
   private static final ApiConfig API_CONFIG = new ApiConfig("/maps/api/elevation/json");
@@ -38,7 +39,7 @@ public class ElevationApi {
   private ElevationApi() {}
 
   /**
-   * Get a set of elevations for a list of points.
+   * Get a list of elevations for a list of points.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param points The points to retrieve elevations for.
@@ -50,8 +51,8 @@ public class ElevationApi {
   }
 
   /**
-   * See <a
-   * href="https://developers.google.com/maps/documentation/elevation/#Paths">documentation</a>.
+   * See <a href="https://developers.google.com/maps/documentation/elevation/intro#Paths">
+   * documentation</a>.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param samples The number of samples to retrieve heights along {@code path}.
@@ -70,8 +71,8 @@ public class ElevationApi {
   }
 
   /**
-   * See <a
-   * href="https://developers.google.com/maps/documentation/elevation/#Paths">documentation</a>.
+   * See <a href="https://developers.google.com/maps/documentation/elevation/intro#Paths">
+   * documentation</a>.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param samples The number of samples to retrieve heights along {@code encodedPolyline}.

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -298,7 +298,7 @@ public class GeoApiContext {
 
     /**
      * Change the RequestHandler.Builder strategy to change between the {@code OkHttpRequestHandler}
-     * and the {@code OkHttpRequestHandler}.
+     * and the {@code GaeRequestHandler}.
      *
      * @param builder The {@code RequestHandler.Builder} to use for {@link #build()}
      * @return Returns this builder for call chaining.
@@ -334,7 +334,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Set the ClientID / Secret pair to use for authorizing requests.
+     * Set the ClientID/Secret pair to use for authorizing requests.
      *
      * @param clientId The Client ID to use.
      * @param cryptographicSecret The Secret to use.

--- a/src/main/java/com/google/maps/GeocodingApi.java
+++ b/src/main/java/com/google/maps/GeocodingApi.java
@@ -33,7 +33,7 @@ public class GeocodingApi {
   private GeocodingApi() {}
 
   /**
-   * create a new Geocoding API request.
+   * Create a new Geocoding API request.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @return Returns the request, ready to run.

--- a/src/main/java/com/google/maps/GeocodingApiRequest.java
+++ b/src/main/java/com/google/maps/GeocodingApiRequest.java
@@ -86,11 +86,11 @@ public class GeocodingApiRequest
 
   /**
    * Set the bounding box of the viewport within which to bias geocode results more prominently.
-   * This parameter will only influence, not fully restrict, results from the geocoder. (
+   * This parameter will only influence, not fully restrict, results from the geocoder.
    *
    * <p>For more information see <a
-   * href="https://developers.google.com/maps/documentation/geocoding/?hl=pl#Viewports">Viewports
-   * documentation</a>.
+   * href="https://developers.google.com/maps/documentation/geocoding/intro?hl=pl#Viewports">
+   * Viewport Biasing</a>.
    *
    * @param southWestBound The South West bound of the bounding box.
    * @param northEastBound The North East bound of the bounding box.
@@ -105,8 +105,8 @@ public class GeocodingApiRequest
    * parameter will only influence, not fully restrict, results from the geocoder.
    *
    * <p>For more information see <a
-   * href="https://developers.google.com/maps/documentation/geocoding/?hl=pl#RegionCodes">Region
-   * Codes</a>.
+   * href="https://developers.google.com/maps/documentation/geocoding/intro?hl=pl#RegionCodes">Region
+   * Biasing</a>.
    *
    * @param region The region code to influence results.
    * @return Returns this {@code GeocodingApiRequest} for call chaining.
@@ -120,7 +120,7 @@ public class GeocodingApiRequest
    * fully restrict the results from the geocoder.
    *
    * <p>For more information see <a
-   * href="https://developers.google.com/maps/documentation/geocoding/?hl=pl#ComponentFiltering">
+   * href="https://developers.google.com/maps/documentation/geocoding/intro?hl=pl#ComponentFiltering">
    * Component Filtering</a>.
    *
    * @param filters Component filters to apply to the request.

--- a/src/main/java/com/google/maps/NearbySearchRequest.java
+++ b/src/main/java/com/google/maps/NearbySearchRequest.java
@@ -61,8 +61,8 @@ public class NearbySearchRequest
 
   /**
    * radius defines the distance (in meters) within which to return place results. The maximum
-   * allowed radius is 50,000 meters. Note that radius must not be included if rankby=DISTANCE is
-   * specified.
+   * allowed radius is 50,000 meters. Note that radius must not be included if {@code
+   * rankby=DISTANCE} is specified.
    *
    * @param distance The distance in meters around the {@link #location(LatLng)} to search.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -138,9 +138,9 @@ public class NearbySearchRequest
   }
 
   /**
-   * nextPageToken returns the next 20 results from a previously run search. Setting nextPageToken
+   * pageToken returns the next 20 results from a previously run search. Setting {@code pageToken}
    * will execute a search with the same parameters used previously — all parameters other than
-   * pageToken will be ignored.
+   * {@code pageToken} will be ignored.
    *
    * @param nextPageToken The page token from a previous result.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -160,7 +160,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * type restricts the results to places matching the specified type. Provide support of multiples
+   * type restricts the results to places matching the specified type. Provides support for multiple
    * types.
    *
    * @param types The {@link PlaceType}s to restrict results to.

--- a/src/main/java/com/google/maps/PendingResultBase.java
+++ b/src/main/java/com/google/maps/PendingResultBase.java
@@ -112,7 +112,7 @@ abstract class PendingResultBase<T, A extends PendingResultBase<T, A, R>, R exte
    * The language in which to return results. Note that we often update supported languages so this
    * list may not be exhaustive.
    *
-   * @param language The language code, e.g. "en-AU" or "es"
+   * @param language The language code, e.g. "en-AU" or "es".
    * @see <a href="https://developers.google.com/maps/faq#languagesupport">List of supported domain
    *     languages</a>
    * @return Returns the request for call chaining.
@@ -123,10 +123,11 @@ abstract class PendingResultBase<T, A extends PendingResultBase<T, A, R>, R exte
 
   /**
    * A channel to pass with the request. channel is used by Google Maps API for Work users to be
-   * able to track usage across different applications with the same clientID. See:
-   * https://developers.google.com/maps/documentation/business/clientside/quota
+   * able to track usage across different applications with the same clientID. See <a
+   * href="https://developers.google.com/maps/documentation/business/clientside/quota">Premium Plan
+   * Usage Rates and Limits</a>.
    *
-   * @param channel String to pass with the request for analytics
+   * @param channel String to pass with the request for analytics.
    * @return Returns the request for call chaining.
    */
   public A channel(String channel) {

--- a/src/main/java/com/google/maps/PlacesApi.java
+++ b/src/main/java/com/google/maps/PlacesApi.java
@@ -44,13 +44,13 @@ public class PlacesApi {
   }
 
   /**
-   * Retrieve the next page of Text Search results. The nextPageToken, returned in a
-   * PlaceSearchResponse when there are more pages of results, encodes all of the original Text
-   * Search Request parameters, and are thus not required on this call.
+   * Retrieve the next page of Nearby Search results. The nextPageToken, returned in a
+   * PlacesSearchResponse when there are more pages of results, encodes all of the original Nearby
+   * Search Request parameters, which are thus not required on this call.
    *
    * @param context The context on which to make Geo API requests.
-   * @param nextPageToken The nextPageToken returned as part of a PlaceSearchResponse.
-   * @return Returns a TextSearchRequest that can be executed.
+   * @param nextPageToken The nextPageToken returned as part of a PlacesSearchResponse.
+   * @return Returns a NearbySearchRequest that can be executed.
    */
   public static NearbySearchRequest nearbySearchNextPage(
       GeoApiContext context, String nextPageToken) {
@@ -60,7 +60,7 @@ public class PlacesApi {
   }
 
   /**
-   * Perform a search for Places using a text query — for example "pizza in New York" or "shoe
+   * Perform a search for Places using a text query; for example, "pizza in New York" or "shoe
    * stores near Ottawa".
    *
    * @param context The context on which to make Geo API requests.
@@ -75,11 +75,11 @@ public class PlacesApi {
 
   /**
    * Retrieve the next page of Text Search results. The nextPageToken, returned in a
-   * PlaceSearchResponse when there are more pages of results, encodes all of the original Text
-   * Search Request parameters, and are thus not required on this call.
+   * PlacesSearchResponse when there are more pages of results, encodes all of the original Text
+   * Search Request parameters, which are thus not required on this call.
    *
    * @param context The context on which to make Geo API requests.
-   * @param nextPageToken The nextPageToken returned as part of a PlaceSearchResponse.
+   * @param nextPageToken The nextPageToken returned as part of a PlacesSearchResponse.
    * @return Returns a TextSearchRequest that can be executed.
    */
   public static TextSearchRequest textSearchNextPage(GeoApiContext context, String nextPageToken) {
@@ -112,10 +112,10 @@ public class PlacesApi {
   /**
    * Request the details of a Place.
    *
-   * <p>We are only enabling looking up Places by placeId as the older Place identifier - reference
-   * - is deprecated. Please see the <a
-   * href="https://developers.google.com/places/web-service/details#deprecation">deprecation
-   * warning</a>.
+   * <p>We are only enabling looking up Places by placeId as the older Place identifier, reference,
+   * is deprecated. Please see the <a
+   * href="https://web.archive.org/web/20170521070241/https://developers.google.com/places/web-service/details#deprecation">
+   * deprecation warning</a>.
    *
    * @param context The context on which to make Geo API requests.
    * @param placeId The PlaceID to request details on.

--- a/src/main/java/com/google/maps/RoadsApi.java
+++ b/src/main/java/com/google/maps/RoadsApi.java
@@ -100,8 +100,9 @@ public class RoadsApi {
    *
    * <p>Note: The accuracy of speed limit data returned by the Google Maps Roads API cannot be
    * guaranteed. Speed limit data provided is not real-time, and may be estimated, inaccurate,
-   * incomplete, and/or outdated. Inaccuracies in our data may be reported through the <a
-   * href="http://www.google.com/mapmaker">Google Map Maker</a> service.
+   * incomplete, and/or outdated. Inaccuracies in our data may be reported through <a
+   * href="https://www.localguidesconnect.com/t5/News-Updates/Exclusive-Edit-a-road-segment-in-Google-Maps/ba-p/149865">
+   * Google Maps Feedback</a>.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param path The collected GPS points as a path.
@@ -116,8 +117,9 @@ public class RoadsApi {
    *
    * <p>Note: The accuracy of speed limit data returned by the Google Maps Roads API cannot be
    * guaranteed. Speed limit data provided is not real-time, and may be estimated, inaccurate,
-   * incomplete, and/or outdated. Inaccuracies in our data may be reported through the <a
-   * href="http://www.google.com/mapmaker">Google Map Maker</a> service.
+   * incomplete, and/or outdated. Inaccuracies in our data may be reported through <a
+   * href="https://www.localguidesconnect.com/t5/News-Updates/Exclusive-Edit-a-road-segment-in-Google-Maps/ba-p/149865">
+   * Google Maps Feedback</a>.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param placeIds The Place ID of the road segment. Place IDs are returned by the {@link
@@ -151,7 +153,7 @@ public class RoadsApi {
 
   /**
    * Takes up to 100 GPS points, and returns the closest road segment for each point. The points
-   * passed do not need to be part of a continuous path
+   * passed do not need to be part of a continuous path.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param points The sequence of points to be aligned to nearest roads

--- a/src/main/java/com/google/maps/TextSearchRequest.java
+++ b/src/main/java/com/google/maps/TextSearchRequest.java
@@ -116,9 +116,9 @@ public class TextSearchRequest
   }
 
   /**
-   * nextPageToken returns the next 20 results from a previously run search. Setting nextPageToken
-   * will execute a search with the same parameters used previously — all parameters other than
-   * pageToken will be ignored.
+   * pageToken returns the next 20 results from a previously run search. Setting pageToken will
+   * execute a search with the same parameters used previously — all parameters other than pageToken
+   * will be ignored.
    *
    * @param nextPageToken A {@code pageToken} from a prior result.
    * @return Returns this {@code TextSearchRequest} for call chaining.

--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -26,7 +26,8 @@ import java.util.TimeZone;
  * The Google Time Zone API provides a simple interface to request the time zone for a location on
  * the earth.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/timezone/">documentation</a>.
+ * <p>See the <a href="https://developers.google.com/maps/documentation/timezone/">Time Zone API
+ * documentation</a>.
  */
 public class TimeZoneApi {
   private static final ApiConfig API_CONFIG =

--- a/src/main/java/com/google/maps/errors/ApiException.java
+++ b/src/main/java/com/google/maps/errors/ApiException.java
@@ -16,7 +16,7 @@
 package com.google.maps.errors;
 
 /**
- * ApiException and it's descendants represent an error returned by the remote API. API errors are
+ * ApiException and its descendants represent an error returned by the remote API. API errors are
  * determined by the {@code status} field returned in any of the Geo API responses.
  */
 public class ApiException extends Exception {

--- a/src/main/java/com/google/maps/errors/MaxElementsExceededException.java
+++ b/src/main/java/com/google/maps/errors/MaxElementsExceededException.java
@@ -18,7 +18,8 @@ package com.google.maps.errors;
 /**
  * Indicates that the product of origins and destinations exceeds the per-query limit.
  *
- * @see <a href="https://developers.google.com/maps/documentation/distancematrix/#Limits">Limits</a>
+ * @see <a href="https://developers.google.com/maps/documentation/distance-matrix/usage-limits">
+ *     Limits</a>
  */
 public class MaxElementsExceededException extends ApiException {
 

--- a/src/main/java/com/google/maps/internal/DateTimeAdapter.java
+++ b/src/main/java/com/google/maps/internal/DateTimeAdapter.java
@@ -59,7 +59,7 @@ public class DateTimeAdapter extends TypeAdapter<DateTime> {
     while (reader.hasNext()) {
       String name = reader.nextName();
       if (name.equals("text")) {
-        // Ignore the human readable rendering.
+        // Ignore the human-readable rendering.
         reader.nextString();
       } else if (name.equals("time_zone")) {
         timeZoneId = reader.nextString();

--- a/src/main/java/com/google/maps/model/AddressComponent.java
+++ b/src/main/java/com/google/maps/model/AddressComponent.java
@@ -18,8 +18,10 @@ package com.google.maps.model;
 /**
  * The parts of an address.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/geocoding/">here for more
- * detail</a>.
+ * <p>See <a href="https://developers.google.com/maps/documentation/geocoding/intro#Types">Address
+ * Types and Address Component Types</a> in the <a
+ * href="https://developers.google.com/maps/documentation/geocoding/intro">Google Maps Geocoding API
+ * Developer's Guide</a> for more detail.
  */
 public class AddressComponent {
   /**

--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -16,9 +16,9 @@
 package com.google.maps.model;
 
 /**
- * The Adress Component types. Please see <a
- * href="https://developers.google.com/maps/documentation/geocoding/#Types">Address Component
- * Types</a> for more detail.
+ * The Address Component types. Please see <a
+ * href="https://developers.google.com/maps/documentation/geocoding/intro#Types">Address Types and
+ * Address Component Types</a> for more detail.
  */
 public enum AddressComponentType {
 

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -19,9 +19,10 @@ import com.google.maps.internal.StringJoin.UrlValue;
 
 /**
  * The Address types. Please see <a
- * href="https://developers.google.com/maps/documentation/geocoding/intro#Types">Address Types</a>
- * for more detail. Some addresses contain additional place categories. Please see <a
- * href="https://developers.google.com/places/documentation/supported_types">Places</a>
+ * href="https://developers.google.com/maps/documentation/geocoding/intro#Types">Address Types and
+ * Address Component Types</a> for more detail. Some addresses contain additional place categories.
+ * Please see <a href="https://developers.google.com/places/supported_types">Place Types</a> for
+ * more detail.
  */
 public enum AddressType implements UrlValue {
 
@@ -94,9 +95,10 @@ public enum AddressType implements UrlValue {
   WARD("ward"),
 
   /**
-   * {@code SUBLOCALITY} indicates a first-order civil entity below a locality. For some locations
-   * may receive one of the additional types: sublocality_level_1 to sublocality_level_5. Each
-   * sublocality level is a civil entity. Larger numbers indicate a smaller geographic area.
+   * {@code SUBLOCALITY} indicates a first-order civil entity below a locality. Some locations may
+   * receive one of the additional types: {@code SUBLOCALITY_LEVEL_1} to {@code
+   * SUBLOCALITY_LEVEL_5}. Each sublocality level is a civil entity. Larger numbers indicate a
+   * smaller geographic area.
    */
   SUBLOCALITY("sublocality"),
   SUBLOCALITY_LEVEL_1("sublocality_level_1"),
@@ -116,7 +118,7 @@ public enum AddressType implements UrlValue {
 
   /**
    * {@code SUBPREMISE} indicates a first-order entity below a named location, usually a singular
-   * building within a collection of buildings with a common name
+   * building within a collection of buildings with a common name.
    */
   SUBPREMISE("subpremise"),
 

--- a/src/main/java/com/google/maps/model/Bounds.java
+++ b/src/main/java/com/google/maps/model/Bounds.java
@@ -15,7 +15,7 @@
 
 package com.google.maps.model;
 
-/** The north east and south west points that delineate the outer bounds of a map. */
+/** The northeast and southwest points that delineate the outer bounds of a map. */
 public class Bounds {
   public LatLng northeast;
   public LatLng southwest;

--- a/src/main/java/com/google/maps/model/CellTower.java
+++ b/src/main/java/com/google/maps/model/CellTower.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 /**
- * Cell tower objects
+ * A cell tower object.
  *
  * <p>The Geolocation API request body's cellTowers array contains zero or more cell tower objects.
  *

--- a/src/main/java/com/google/maps/model/ComponentFilter.java
+++ b/src/main/java/com/google/maps/model/ComponentFilter.java
@@ -25,7 +25,7 @@ import com.google.maps.internal.StringJoin;
  * specified using the components filter.
  *
  * <p>Please see <a
- * href="https://developers.google.com/maps/documentation/geocoding/#ComponentFiltering">Component
+ * href="https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering">Component
  * Filtering</a> for more detail.
  */
 public class ComponentFilter implements StringJoin.UrlValue {

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -46,7 +46,7 @@ public class DirectionsStep {
   public Distance distance;
 
   /**
-   * {@code maneuver} contains the maneuver required to move ahead. eg., turn-left. Please note,
+   * {@code maneuver} contains the maneuver required to move ahead. E.g., turn-left. Please note,
    * this field is undocumented, and thus should not be relied upon.
    */
   @Deprecated public String maneuver;

--- a/src/main/java/com/google/maps/model/Distance.java
+++ b/src/main/java/com/google/maps/model/Distance.java
@@ -26,7 +26,7 @@ public class Distance {
 
   /**
    * This is the human friendly distance. This is rounded and in an appropriate unit for the
-   * request. The units can be overriden with a request parameter.
+   * request. The units can be overridden with a request parameter.
    */
   public String humanReadable;
 

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 /**
- * A single result corresponding to a origin/destination pair in a Distance Matrix response.
+ * A single result corresponding to an origin/destination pair in a Distance Matrix response.
  *
  * <p>Be sure to check the status for each element, as a matrix response can have a mix of
  * successful and failed elements depending on the connectivity of the origin and destination.
@@ -30,7 +30,7 @@ public class DistanceMatrixElement {
    */
   public DistanceMatrixElementStatus status;
 
-  /** {@code duration} indicates the total duration of this leg */
+  /** {@code duration} indicates the total duration of this leg. */
   public Duration duration;
 
   /**
@@ -51,9 +51,6 @@ public class DistanceMatrixElement {
   /** {@code distance} indicates the total distance covered by this leg. */
   public Distance distance;
 
-  /**
-   * {@code fare} indicates the contains information about the fare (that is, the ticket costs) on
-   * this route.
-   */
+  /** {@code fare} contains information about the fare (that is, the ticket costs) on this route. */
   public Fare fare;
 }

--- a/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
@@ -23,7 +23,7 @@ package com.google.maps.model;
  *     Documentation on status codes</a>
  */
 public enum DistanceMatrixElementStatus {
-  /** {@code OK} indicates the response contains a valid result. */
+  /** {@code OK} indicates that the response contains a valid result. */
   OK,
 
   /**
@@ -32,6 +32,8 @@ public enum DistanceMatrixElementStatus {
    */
   NOT_FOUND,
 
-  /** {@code ZERO_RESULTS} indicates no route could be found between the origin and destination. */
+  /**
+   * {@code ZERO_RESULTS} indicates that no route could be found between the origin and destination.
+   */
   ZERO_RESULTS
 }

--- a/src/main/java/com/google/maps/model/Fare.java
+++ b/src/main/java/com/google/maps/model/Fare.java
@@ -21,7 +21,7 @@ import java.util.Currency;
 /**
  * A representation of ticket cost for use on public transit.
  *
- * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro#Routes">the
+ * <p>See the <a href="https://developers.google.com/maps/documentation/directions/intro#Routes">
  * Routes Documentation</a> for more detail.
  */
 public class Fare {

--- a/src/main/java/com/google/maps/model/GeolocationPayload.java
+++ b/src/main/java/com/google/maps/model/GeolocationPayload.java
@@ -19,13 +19,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Request body The following fields are supported, and all fields are optional:
+ * Request body.
  *
  * <p>Please see <a
  * href="https://developers.google.com/maps/documentation/geolocation/intro#requests">Geolocation
- * Requests</a> for more detail.
+ * Requests</a> and <a
+ * href="https://developers.google.com/maps/documentation/geolocation/intro#body">Request Body</a>
+ * for more detail.
  *
- * <p>https://developers.google.com/maps/documentation/geolocation/intro#body
+ * <p>The following fields are supported, and all fields are optional:
  */
 public class GeolocationPayload {
   public GeolocationPayload() {}
@@ -60,16 +62,19 @@ public class GeolocationPayload {
   /** {@code carrier}: The carrier name. */
   public String carrier = null;
   /**
-   * considerIp: Specifies whether to fall back to IP geolocation if wifi and cell tower signals are
-   * not available. Note that the IP address in the request header may not be the IP of the device.
-   * Defaults to true. Set considerIp to false to disable fall back.
+   * {@code considerIp}: Specifies whether to fall back to IP geolocation if wifi and cell tower
+   * signals are not available. Note that the IP address in the request header may not be the IP of
+   * the device. Defaults to true. Set considerIp to false to disable fall back.
    */
   public Boolean considerIp = null;
-  /** {@code cellTowers}: An array of cell tower objects. See the Cell Tower Objects. */
+  /**
+   * {@code cellTowers}: An array of cell tower objects. See {@link
+   * com.google.maps.model.CellTower}.
+   */
   public CellTower[] cellTowers;
   /**
-   * {@code wifiAccessPoints}: An array of WiFi access point objects. See the WiFi Access Point
-   * Objects.
+   * {@code wifiAccessPoints}: An array of WiFi access point objects. See {@link
+   * com.google.maps.model.WifiAccessPoint}.
    */
   public WifiAccessPoint[] wifiAccessPoints;
 

--- a/src/main/java/com/google/maps/model/GeolocationResult.java
+++ b/src/main/java/com/google/maps/model/GeolocationResult.java
@@ -16,13 +16,13 @@
 package com.google.maps.model;
 
 /**
- * Geolocation Results
+ * Geolocation Results.
  *
  * <p>A successful geolocation request will return a result defining a location and radius.
  *
  * <p>Please see <a
  * href="https://developers.google.com/maps/documentation/geolocation/intro#responses">Geolocation
- * results</a> for more detail.
+ * responses</a> for more detail.
  */
 public class GeolocationResult {
   /**

--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 import com.google.maps.internal.StringJoin.UrlValue;
 import java.util.Locale;
 
-/** A place on Earth, represented by a Latitude/Longitude pair. */
+/** A place on Earth, represented by a latitude/longitude pair. */
 public class LatLng implements UrlValue {
 
   /** The latitude of this location. */
@@ -28,7 +28,7 @@ public class LatLng implements UrlValue {
   public double lng;
 
   /**
-   * Construct a location with a latitude longitude pair.
+   * Construct a location with a latitude/longitude pair.
    *
    * @param lat The latitude of this location.
    * @param lng The longitude of this location.

--- a/src/main/java/com/google/maps/model/LocationType.java
+++ b/src/main/java/com/google/maps/model/LocationType.java
@@ -19,8 +19,8 @@ import com.google.maps.internal.StringJoin.UrlValue;
 
 /**
  * Location types for a reverse geocoding request. Please see <a
- * href="https://developers.google.com/maps/documentation/geocoding/#ReverseGeocoding">for more
- * detail</a>.
+ * href="https://developers.google.com/maps/documentation/geocoding/start#reverse">Reverse
+ * Geocoding</a> for more detail.
  */
 public enum LocationType implements UrlValue {
   /**

--- a/src/main/java/com/google/maps/model/OpeningHours.java
+++ b/src/main/java/com/google/maps/model/OpeningHours.java
@@ -71,7 +71,7 @@ public class OpeningHours {
 
   /**
    * weekdayText is an array of seven strings representing the formatted opening hours for each day
-   * of the week, for example "Monday: 8:30 am – 5:30 pm".
+   * of the week; for example, "Monday: 8:30 am – 5:30 pm".
    */
   public String[] weekdayText;
 

--- a/src/main/java/com/google/maps/model/Photo.java
+++ b/src/main/java/com/google/maps/model/Photo.java
@@ -18,8 +18,8 @@ package com.google.maps.model;
 /**
  * This describes a photo available with a Search Result.
  *
- * <p>Please see <a href="https://developers.google.com/places/web-service/photos">Photos</a> for
- * more details.
+ * <p>Please see <a href="https://developers.google.com/places/web-service/photos">Place Photos</a>
+ * for more details.
  */
 public class Photo {
   /** photoReference is used to identify the photo when you perform a Photo request. */

--- a/src/main/java/com/google/maps/model/PhotoResult.java
+++ b/src/main/java/com/google/maps/model/PhotoResult.java
@@ -18,8 +18,8 @@ package com.google.maps.model;
 /**
  * PhotoResult contains the photo for a PhotoReference.
  *
- * <p>Please see <a href="https://developers.google.com/places/web-service/photos">Photos</a> for
- * more details.
+ * <p>Please see <a href="https://developers.google.com/places/web-service/photos">Place Photos</a>
+ * for more details.
  */
 public class PhotoResult {
   /** imageData is the byte array of returned image data from the Photos API call. */

--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -142,7 +142,7 @@ public class PlaceDetails {
      */
     public String authorName;
 
-    /** authorUrl the URL to the users Google+ profile, if available. */
+    /** authorUrl the URL to the user's Google+ profile, if available. */
     public URL authorUrl;
 
     /** language an IETF language code indicating the language used in the user's review. */
@@ -190,7 +190,7 @@ public class PlaceDetails {
    */
   public String vicinity;
 
-  /** website lists the authoritative website for this place, such as a business' homepage. */
+  /** website lists the authoritative website for this place, such as a business's homepage. */
   public URL website;
 
   /**

--- a/src/main/java/com/google/maps/model/PlacesSearchResult.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResult.java
@@ -18,8 +18,8 @@ package com.google.maps.model;
 import java.net.URL;
 
 /**
- * PlaceSearchResult represents a single result in the search results return from the Google Places
- * API Web Service.
+ * PlacesSearchResult represents a single result in the search results returned from the Google
+ * Places API Web Service.
  *
  * <p>Please see <a
  * href="https://developers.google.com/places/web-service/search#PlaceSearchResults">Place Search
@@ -60,7 +60,7 @@ public class PlacesSearchResult {
   /** types contains an array of feature types describing the given result. */
   public String types[];
 
-  /** openingHours may contain whether the place is open now or not. */
+  /** openingHours may contain information on when the place is open. */
   public OpeningHours openingHours;
 
   /** photos is an array of photo objects, each containing a reference to an image. */

--- a/src/main/java/com/google/maps/model/SnappedPoint.java
+++ b/src/main/java/com/google/maps/model/SnappedPoint.java
@@ -17,7 +17,7 @@ package com.google.maps.model;
 
 /** A point that has been snapped to a road by the Roads API. */
 public class SnappedPoint {
-  /** {@code location} contains a latitude and longitude value representing the snapped location. */
+  /** {@code location} contains a latitude/longitude value representing the snapped location. */
   public LatLng location;
 
   /**
@@ -28,7 +28,7 @@ public class SnappedPoint {
    * from 0, so a point with an originalIndex of 4 will be the snapped value of the 5th lat/lng
    * passed to the path parameter.
    *
-   * <p>A point that was not on the original path, or when interpolate=false will have an
+   * <p>A point that was not on the original path, or when interpolate=false, will have an
    * originalIndex of -1.
    */
   public int originalIndex = -1;

--- a/src/main/java/com/google/maps/model/StopDetails.java
+++ b/src/main/java/com/google/maps/model/StopDetails.java
@@ -24,9 +24,9 @@ package com.google.maps.model;
  */
 public class StopDetails {
 
-  /** The name of the transit station/stop. eg. "Union Square". */
+  /** The name of the transit station/stop. E.g. "Union Square". */
   public String name;
 
-  /** The location of the transit station/stop, represented as a lat and lng field. */
+  /** The location of the transit station/stop, represented as a latitude/longitude value. */
   public LatLng location;
 }

--- a/src/main/java/com/google/maps/model/TrafficModel.java
+++ b/src/main/java/com/google/maps/model/TrafficModel.java
@@ -18,7 +18,7 @@ package com.google.maps.model;
 import com.google.maps.internal.StringJoin.UrlValue;
 import java.util.Locale;
 
-/** Specifies traffic prediction model when request future directions. */
+/** Specifies traffic prediction model when requesting future directions. */
 public enum TrafficModel implements UrlValue {
   BEST_GUESS,
   OPTIMISTIC,

--- a/src/main/java/com/google/maps/model/TransitAgency.java
+++ b/src/main/java/com/google/maps/model/TransitAgency.java
@@ -20,7 +20,7 @@ package com.google.maps.model;
  *
  * <p>See <a
  * href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">Transit
- * details</a> for more detail.
+ * Details</a> for more detail.
  */
 public class TransitAgency {
 

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -19,7 +19,7 @@ import org.joda.time.DateTime;
 
 /**
  * Transit directions return additional information that is not relevant for other modes of
- * transportation. These additional properties are exposed through the {@code transit_details}
+ * transportation. These additional properties are exposed through the {@code TransitDetails}
  * object, returned as a field of an element in the {@code steps} array. From the {@code
  * TransitDetails} object you can access additional information about the transit stop, transit line
  * and transit agency.
@@ -60,7 +60,7 @@ public class TransitDetails {
   /**
    * {@code numStops} contains the number of stops in this step, counting the arrival stop, but not
    * the departure stop. For example, if your directions involve leaving from Stop A, passing
-   * through stops B and C, and arriving at stop D, {@code numStops} will return 3.
+   * through stops B and C, and arriving at stop D, {@code numStops} will equal 3.
    */
   public int numStops;
 

--- a/src/main/java/com/google/maps/model/TransitLine.java
+++ b/src/main/java/com/google/maps/model/TransitLine.java
@@ -20,11 +20,11 @@ package com.google.maps.model;
  *
  * <p>See <a
  * href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">Transit
- * details</a> for more detail.
+ * Details</a> for more detail.
  */
 public class TransitLine {
 
-  /** {@code name} contains the full name of this transit line. eg. "7 Avenue Express". */
+  /** {@code name} contains the full name of this transit line. E.g. "7 Avenue Express". */
   public String name;
 
   /**

--- a/src/main/java/com/google/maps/model/TravelMode.java
+++ b/src/main/java/com/google/maps/model/TravelMode.java
@@ -24,9 +24,8 @@ import java.util.Locale;
  *
  * @see <a href="https://developers.google.com/maps/documentation/directions/intro#TravelModes">
  *     Directions API travel modes</a>
- * @see <a
- *     href="https://developers.google.com/maps/documentation/distancematrix/#RequestParameters">
- *     Distance Matrix API travel modes</a>
+ * @see <a href="https://developers.google.com/maps/documentation/distance-matrix/intro">Distance
+ *     Matrix API Intro</a>
  */
 public enum TravelMode implements UrlValue {
   DRIVING,

--- a/src/main/java/com/google/maps/model/Vehicle.java
+++ b/src/main/java/com/google/maps/model/Vehicle.java
@@ -24,7 +24,7 @@ package com.google.maps.model;
  */
 public class Vehicle {
 
-  /** {@code name} contains the name of the vehicle on this line. eg. "Subway." */
+  /** {@code name} contains the name of the vehicle on this line. E.g. "Subway." */
   public String name;
 
   /**

--- a/src/main/java/com/google/maps/model/WifiAccessPoint.java
+++ b/src/main/java/com/google/maps/model/WifiAccessPoint.java
@@ -16,10 +16,10 @@
 package com.google.maps.model;
 
 /**
- * WiFi access point objects
+ * WiFi access point objects.
  *
- * <p>The request body's wifiAccessPoints array must contain two or more WiFi access point objects.
- * {@code macAddress} is required; all other fields are optional.
+ * <p>The request body's {@code wifiAccessPoints} array must contain two or more WiFi access point
+ * objects. {@code macAddress} is required; all other fields are optional.
  *
  * <p>Please see <a
  * href="https://developers.google.com/maps/documentation/geolocation/intro#wifi_access_point_object">


### PR DESCRIPTION
Updates various outdated/broken links, and fixes some typos and grammatical errors.

Changes are restricted to the Javadocs.