### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes A-C)

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponent.java
+++ b/src/main/java/com/google/maps/model/AddressComponent.java
@@ -24,21 +24,16 @@ package com.google.maps.model;
  * Developer's Guide</a> for more detail.
  */
 public class AddressComponent {
-  /**
-   * {@code longName} is the full text description or name of the address component as returned by
-   * the Geocoder.
-   */
+  /** The full text description or name of the address component as returned by the Geocoder. */
   public String longName;
 
   /**
-   * {@code shortName} is an abbreviated textual name for the address component, if available. For
-   * example, an address component for the state of Alaska may have a longName of "Alaska" and a
-   * shortName of "AK" using the 2-letter postal abbreviation.
+   * An abbreviated textual name for the address component, if available. For example, an address
+   * component for the state of Alaska may have a longName of "Alaska" and a shortName of "AK" using
+   * the 2-letter postal abbreviation.
    */
   public String shortName;
 
-  /**
-   * This indicates the type of each part of the address. Examples include street number or country.
-   */
+  /** Indicates the type of each part of the address. Examples include street number or country. */
   public AddressComponentType[] types;
 }

--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -22,78 +22,67 @@ package com.google.maps.model;
  */
 public enum AddressComponentType {
 
-  /** {@code STREET_ADDRESS} indicates a precise street address. */
+  /** A precise street address. */
   STREET_ADDRESS("street_address"),
 
-  /** {@code ROUTE} indicates a named route (such as "US 101"). */
+  /** A named route (such as "US 101"). */
   ROUTE("route"),
 
-  /** {@code INTERSECTION} indicates a major intersection, usually of two major roads. */
+  /** A major intersection, usually of two major roads. */
   INTERSECTION("intersection"),
 
-  /**
-   * {@code POLITICAL} indicates a political entity. Usually, this type indicates a polygon of some
-   * civil administration.
-   */
+  /** A political entity. Usually, this type indicates a polygon of some civil administration. */
   POLITICAL("political"),
 
-  /**
-   * {@code COUNTRY} indicates the national political entity, and is typically the highest order
-   * type returned by the Geocoder.
-   */
+  /** A national political entity, typically the highest order type returned by the Geocoder. */
   COUNTRY("country"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_1} indicates a first-order civil entity below the country
-   * level. Within the United States, these administrative levels are states. Not all nations
-   * exhibit these administrative levels.
+   * A first-order civil entity below the country level. Within the United States, these
+   * administrative levels are states. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_1("administrative_area_level_1"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_2} indicates a second-order civil entity below the country
-   * level. Within the United States, these administrative levels are counties. Not all nations
-   * exhibit these administrative levels.
+   * A second-order civil entity below the country level. Within the United States, these
+   * administrative levels are counties. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_2("administrative_area_level_2"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_3} indicates a third-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A third-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_3("administrative_area_level_3"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_4} indicates a fourth-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A fourth-order civil entity below the country level. This type indicates a minor civil
+   * division. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_4("administrative_area_level_4"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_5} indicates a fifth-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A fifth-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_5("administrative_area_level_5"),
 
-  /** {@code COLLOQUIAL_AREA} indicates a commonly-used alternative name for the entity. */
+  /** A commonly-used alternative name for the entity. */
   COLLOQUIAL_AREA("colloquial_area"),
 
-  /** {@code LOCALITY} indicates an incorporated city or town political entity. */
+  /** An incorporated city or town political entity. */
   LOCALITY("locality"),
 
   /**
-   * {@code WARD} indicates a specific type of Japanese locality, to facilitate distinction between
-   * multiple locality components within a Japanese address.
+   * A specific type of Japanese locality, used to facilitate distinction between multiple locality
+   * components within a Japanese address.
    */
   WARD("ward"),
 
   /**
-   * {@code SUBLOCALITY} indicates a first-order civil entity below a locality. For some locations
-   * may receive one of the additional types: sublocality_level_1 to sublocality_level_5. Each
-   * sublocality level is a civil entity. Larger numbers indicate a smaller geographic area.
+   * A first-order civil entity below a locality. For some locations may receive one of the
+   * additional types: sublocality_level_1 to sublocality_level_5. Each sublocality level is a civil
+   * entity. Larger numbers indicate a smaller geographic area.
    */
   SUBLOCALITY("sublocality"),
   SUBLOCALITY_LEVEL_1("sublocality_level_1"),
@@ -102,91 +91,79 @@ public enum AddressComponentType {
   SUBLOCALITY_LEVEL_4("sublocality_level_4"),
   SUBLOCALITY_LEVEL_5("sublocality_level_5"),
 
-  /** {@code NEIGHBORHOOD} indicates a named neighborhood. */
+  /** A named neighborhood. */
   NEIGHBORHOOD("neighborhood"),
 
-  /**
-   * {@code PREMISE} indicates a named location, usually a building or collection of buildings with
-   * a common name.
-   */
+  /** A named location, usually a building or collection of buildings with a common name. */
   PREMISE("premise"),
 
   /**
-   * {@code SUBPREMISE} indicates a first-order entity below a named location, usually a singular
-   * building within a collection of buildings with a common name
+   * A first-order entity below a named location, usually a singular building within a collection of
+   * buildings with a common name.
    */
   SUBPREMISE("subpremise"),
 
-  /**
-   * {@code POSTAL_CODE} indicates a postal code as used to address postal mail within the country.
-   */
+  /** A postal code as used to address postal mail within the country. */
   POSTAL_CODE("postal_code"),
 
-  /**
-   * {@code POSTAL_CODE_PREFIX} indicates a postal code prefix as used to address postal mail within
-   * the country.
-   */
+  /** A postal code prefix as used to address postal mail within the country. */
   POSTAL_CODE_PREFIX("postal_code_prefix"),
 
-  /**
-   * {@code POSTAL_CODE_SUFFIX} indicates a postal code suffix as used to address postal mail within
-   * the country.
-   */
+  /** A postal code suffix as used to address postal mail within the country. */
   POSTAL_CODE_SUFFIX("postal_code_suffix"),
 
-  /** {@code NATURAL_FEATURE} indicates a prominent natural feature. */
+  /** A prominent natural feature. */
   NATURAL_FEATURE("natural_feature"),
 
-  /** {@code AIRPORT} indicates an airport. */
+  /** An airport. */
   AIRPORT("airport"),
 
-  /** {@code PARK} indicates a named park. */
+  /** A named park. */
   PARK("park"),
 
   /**
-   * {@code POINT_OF_INTEREST} indicates a named point of interest. Typically, these "POI"s are
-   * prominent local entities that don't easily fit in another category, such as "Empire State
-   * Building" or "Statue of Liberty."
+   * A named point of interest. Typically, these "POI"s are prominent local entities that don't
+   * easily fit in another category, such as "Empire State Building" or "Statue of Liberty."
    */
   POINT_OF_INTEREST("point_of_interest"),
 
-  /** {@code FLOOR} indicates the floor of a building address. */
+  /** The floor of a building address. */
   FLOOR("floor"),
 
-  /** {@code ESTABLISHMENT} typically indicates a place that has not yet been categorized. */
+  /** Typically indicates a place that has not yet been categorized. */
   ESTABLISHMENT("establishment"),
 
-  /** {@code PARKING} indicates a parking lot or parking structure. */
+  /** A parking lot or parking structure. */
   PARKING("parking"),
 
-  /** {@code POST_BOX} indicates a specific postal box. */
+  /** A specific postal box. */
   POST_BOX("post_box"),
 
   /**
-   * {@code POSTAL_TOWN} indicates a grouping of geographic areas, such as locality and sublocality,
-   * used for mailing addresses in some countries.
+   * A grouping of geographic areas, such as locality and sublocality, used for mailing addresses in
+   * some countries.
    */
   POSTAL_TOWN("postal_town"),
 
-  /** {@code ROOM} indicates the room of a building address. */
+  /** The room of a building address. */
   ROOM("room"),
 
-  /** {@code STREET_NUMBER} indicates the precise street number. */
+  /** The precise street number of an address. */
   STREET_NUMBER("street_number"),
 
-  /** {@code BUS_STATION} indicates the location of a bus stop. */
+  /** The location of a bus stop. */
   BUS_STATION("bus_station"),
 
-  /** {@code TRAIN_STATION} indicates the location of a train station. */
+  /** The location of a train station. */
   TRAIN_STATION("train_station"),
 
-  /** {@code SUBWAY_STATION} indicates the location of a subway station. */
+  /** The location of a subway station. */
   SUBWAY_STATION("subway_station"),
 
-  /** {@code TRANSIT_STATION} indicates the location of a transit station. */
+  /** The location of a transit station. */
   TRANSIT_STATION("transit_station"),
 
-  /** {@code LIGHT_RAIL_STATION} indicates the location of a light rail station. */
+  /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
   /**

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -26,77 +26,70 @@ import com.google.maps.internal.StringJoin.UrlValue;
  */
 public enum AddressType implements UrlValue {
 
-  /** {@code STREET_ADDRESS} indicates a precise street address. */
+  /** A precise street address. */
   STREET_ADDRESS("street_address"),
 
-  /** {@code ROUTE} indicates a named route (such as "US 101"). */
+  /** A named route (such as "US 101"). */
   ROUTE("route"),
 
-  /** {@code INTERSECTION} indicates a major intersection, usually of two major roads. */
+  /** A major intersection, usually of two major roads. */
   INTERSECTION("intersection"),
 
   /**
-   * {@code POLITICAL} indicates a political entity. Usually, this type indicates a polygon of some
-   * civil administration.
+   * A political entity. Usually, this type indicates a polygon of some civil administration.
    */
   POLITICAL("political"),
 
   /**
-   * {@code COUNTRY} indicates the national political entity, and is typically the highest order
-   * type returned by the Geocoder.
+   * The national political entity, typically the highest order type returned by the Geocoder.
    */
   COUNTRY("country"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_1} indicates a first-order civil entity below the country
-   * level. Within the United States, these administrative levels are states. Not all nations
-   * exhibit these administrative levels.
+   * A first-order civil entity below the country level. Within the United States, these
+   * administrative levels are states. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_1("administrative_area_level_1"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_2} indicates a second-order civil entity below the country
-   * level. Within the United States, these administrative levels are counties. Not all nations
-   * exhibit these administrative levels.
+   * A second-order civil entity below the country level. Within the United States, these
+   * administrative levels are counties. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_2("administrative_area_level_2"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_3} indicates a third-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A third-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_3("administrative_area_level_3"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_4} indicates a fourth-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A fourth-order civil entity below the country level. This type indicates a minor civil
+   * division. Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_4("administrative_area_level_4"),
 
   /**
-   * {@code ADMINISTRATIVE_AREA_LEVEL_5} indicates a fifth-order civil entity below the country
-   * level. This type indicates a minor civil division. Not all nations exhibit these administrative
-   * levels.
+   * A fifth-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
    */
   ADMINISTRATIVE_AREA_LEVEL_5("administrative_area_level_5"),
 
-  /** {@code COLLOQUIAL_AREA} indicates a commonly-used alternative name for the entity. */
+  /** A commonly-used alternative name for the entity. */
   COLLOQUIAL_AREA("colloquial_area"),
 
-  /** {@code LOCALITY} indicates an incorporated city or town political entity. */
+  /** An incorporated city or town political entity. */
   LOCALITY("locality"),
 
   /**
-   * {@code WARD} indicates a specific type of Japanese locality, to facilitate distinction between
-   * multiple locality components within a Japanese address.
+   * A specific type of Japanese locality, used to facilitate distinction between multiple locality
+   * components within a Japanese address.
    */
   WARD("ward"),
 
   /**
-   * {@code SUBLOCALITY} indicates a first-order civil entity below a locality. Some locations may
-   * receive one of the additional types: {@code SUBLOCALITY_LEVEL_1} to {@code
+   * A first-order civil entity below a locality. Some locations may receive one of the
+   * additional types: {@code SUBLOCALITY_LEVEL_1} to {@code
    * SUBLOCALITY_LEVEL_5}. Each sublocality level is a civil entity. Larger numbers indicate a
    * smaller geographic area.
    */
@@ -107,142 +100,139 @@ public enum AddressType implements UrlValue {
   SUBLOCALITY_LEVEL_4("sublocality_level_4"),
   SUBLOCALITY_LEVEL_5("sublocality_level_5"),
 
-  /** {@code NEIGHBORHOOD} indicates a named neighborhood. */
+  /** A named neighborhood. */
   NEIGHBORHOOD("neighborhood"),
 
   /**
-   * {@code PREMISE} indicates a named location, usually a building or collection of buildings with
-   * a common name.
+   * A named location, usually a building or collection of buildings with a common name.
    */
   PREMISE("premise"),
 
   /**
-   * {@code SUBPREMISE} indicates a first-order entity below a named location, usually a singular
-   * building within a collection of buildings with a common name.
+   * A first-order entity below a named location, usually a singular building within a collection of
+   * buildings with a common name.
    */
   SUBPREMISE("subpremise"),
 
   /**
-   * {@code POSTAL_CODE} indicates a postal code as used to address postal mail within the country.
+   * A postal code as used to address postal mail within the country.
    */
   POSTAL_CODE("postal_code"),
 
   /**
-   * {@code POSTAL_CODE_PREFIX} indicates a postal code prefix as used to address postal mail within
-   * the country.
+   * A postal code prefix as used to address postal mail within the country.
    */
   POSTAL_CODE_PREFIX("postal_code_prefix"),
 
-  /** {@code NATURAL_FEATURE} indicates a prominent natural feature. */
+  /** A prominent natural feature. */
   NATURAL_FEATURE("natural_feature"),
 
-  /** {@code AIRPORT} indicates an airport. */
+  /** An airport. */
   AIRPORT("airport"),
 
-  /** {@code UNIVERSITY} indicates a university. */
+  /** A university. */
   UNIVERSITY("university"),
 
-  /** {@code PARK} indicates a named park. */
+  /** A named park. */
   PARK("park"),
 
   /**
-   * {@code POINT_OF_INTEREST} indicates a named point of interest. Typically, these "POI"s are
-   * prominent local entities that don't easily fit in another category, such as "Empire State
-   * Building" or "Statue of Liberty."
+   * A named point of interest. Typically, these "POI"s are prominent local entities that don't
+   * easily fit in another category, such as "Empire State Building" or "Statue of Liberty."
    */
   POINT_OF_INTEREST("point_of_interest"),
 
-  /** {@code ESTABLISHMENT} typically indicates a place that has not yet been categorized. */
+  /** A place that has not yet been categorized. */
   ESTABLISHMENT("establishment"),
 
-  /** {@code BUS_STATION} indicates the location of a bus stop. */
+  /** The location of a bus stop. */
   BUS_STATION("bus_station"),
 
-  /** {@code TRAIN_STATION} indicates the location of a train station. */
+  /** The location of a train station. */
   TRAIN_STATION("train_station"),
 
-  /** {@code SUBWAY_STATION} indicates the location of a subway station. */
+  /** The location of a subway station. */
   SUBWAY_STATION("subway_station"),
 
-  /** {@code TRANSIT_STATION} indicates the location of a transit station. */
+  /** The location of a transit station. */
   TRANSIT_STATION("transit_station"),
 
-  /** {@code LIGHT_RAIL_STATION} indicates the location of a light rail station. */
+  /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
-  /** {@code CHURCH} indicates the location of a church. */
+  /** The location of a church. */
   CHURCH("church"),
 
-  /** {@code FINANCE} indicates the location of a finance institute. */
+  /** The location of a finance institute. */
   FINANCE("finance"),
 
-  /** {@code POST_OFFICE} indicates the location of a post office. */
+  /** The location of a post office. */
   POST_OFFICE("post_office"),
 
-  /** {@code PLACE_OF_WORSHIP} indicates the location of a place of worship. */
+  /** The location of a place of worship. */
   PLACE_OF_WORSHIP("place_of_worship"),
 
   /**
-   * {@code POSTAL_TOWN} indicates a grouping of geographic areas, such as locality and sublocality,
-   * used for mailing addresses in some countries.
+   * A grouping of geographic areas, such as locality and sublocality, used for mailing addresses in
+   * some countries.
    */
   POSTAL_TOWN("postal_town"),
 
-  /** {@code SYNAGOGUE} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   SYNAGOGUE("synagogue"),
 
-  /** {@code FOOD} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   FOOD("food"),
 
-  /** {@code GROCERY_OR_SUPERMARKET} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   GROCERY_OR_SUPERMARKET("grocery_or_supermarket"),
 
-  /** {@code STORE} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   STORE("store"),
 
-  /** {@code LAWYER} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   LAWYER("lawyer"),
 
-  /** {@code HEALTH} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   HEALTH("health"),
 
-  /** {@code INSURANCE_AGENCY} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   INSURANCE_AGENCY("insurance_agency"),
 
-  /** {@code GAS_STATION} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   GAS_STATION("gas_station"),
 
-  /** {@code CAR_DEALER} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   CAR_DEALER("car_dealer"),
 
-  /** {@code CAR_REPAIR} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   CAR_REPAIR("car_repair"),
 
-  /** {@code MEAL_TAKEAWAY} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   MEAL_TAKEAWAY("meal_takeaway"),
 
-  /** {@code FURNITURE_STORE} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   FURNITURE_STORE("furniture_store"),
 
-  /** {@code HOME_GOODS_STORE} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   HOME_GOODS_STORE("home_goods_store"),
 
-  /** {@code SHOPPING_MALL} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   SHOPPING_MALL("shopping_mall"),
 
-  /** {@code GYM} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   GYM("gym"),
 
-  /** {@code ACCOUNTING} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   ACCOUNTING("accounting"),
 
-  /** {@code MOVING_COMPANY} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   MOVING_COMPANY("moving_company"),
 
-  /** {@code LODGING} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   LODGING("lodging"),
 
-  /** {@code STORAGE} is currently not a documented return type. */
+  /** Currently not a documented return type. */
   STORAGE("storage"),
 
   /**

--- a/src/main/java/com/google/maps/model/AutocompletePrediction.java
+++ b/src/main/java/com/google/maps/model/AutocompletePrediction.java
@@ -16,8 +16,7 @@
 package com.google.maps.model;
 
 /**
- * AutocompletePrediction represents a single Autocomplete result returned from the Google Places
- * API Web Service.
+ * Represents a single Autocomplete result returned from the Google Places API Web Service.
  *
  * <p>Please see <a
  * href="https://developers.google.com/places/web-service/query#query_autocomplete_responses">Query
@@ -32,7 +31,7 @@ public class AutocompletePrediction {
   public String placeId;
 
   /**
-   * types is an array indicating the type of the address component.
+   * An array indicating the type of the address component.
    *
    * <p>Please see <a href="https://developers.google.com/places/supported_types">supported
    * types</a> for a list of types that can be returned.
@@ -40,37 +39,36 @@ public class AutocompletePrediction {
   public String types[];
 
   /**
-   * terms contains an array of terms identifying each section of the returned description (a
-   * section of the description is generally terminated with a comma). Each entry in the array has a
-   * value field, containing the text of the term, and an offset field, defining the start position
-   * of this term in the description, measured in Unicode characters.
+   * An array of terms identifying each section of the returned description. (A section of the
+   * description is generally terminated with a comma.) Each entry in the array has a value field,
+   * containing the text of the term, and an offset field, defining the start position of this term
+   * in the description, measured in Unicode characters.
    */
   public Term terms[];
 
   /**
-   * MatchedSubstring describes the location of the entered term in the prediction result text, so
-   * that the term can be highlighted if desired.
+   * Describes the location of the entered term in the prediction result text, so that the term can
+   * be highlighted if desired.
    */
   public static class MatchedSubstring {
 
-    /** length describes the length of the matched substring. */
+    /** The length of the matched substring. */
     public int length;
 
-    /** offset defines the start position of the matched substring. */
+    /** The start position of the matched substring. */
     public int offset;
   }
 
   public MatchedSubstring matchedSubstrings[];
 
   /**
-   * Term identifies each section of the returned description (a section of the description is
-   * generally terminated with a comma).
+   * Identifies each section of the returned description. (A section of the description is
+   * generally terminated with a comma.)
    */
   public static class Term {
 
     /**
-     * offset defines the start position of this term in the description, measured in Unicode
-     * characters.
+     * The start position of this term in the description, measured in Unicode characters.
      */
     public int offset;
 

--- a/src/main/java/com/google/maps/model/Bounds.java
+++ b/src/main/java/com/google/maps/model/Bounds.java
@@ -17,6 +17,8 @@ package com.google.maps.model;
 
 /** The northeast and southwest points that delineate the outer bounds of a map. */
 public class Bounds {
+  /** The northeast corner of the bounding box. */
   public LatLng northeast;
+  /** The southwest corner of the bounding box. */
   public LatLng southwest;
 }

--- a/src/main/java/com/google/maps/model/CellTower.java
+++ b/src/main/java/com/google/maps/model/CellTower.java
@@ -45,33 +45,33 @@ public class CellTower {
     this.timingAdvance = _timingAdvance;
   }
   /**
-   * {@code cellId} (required): Unique identifier of the cell. On GSM, this is the Cell ID (CID);
-   * CDMA networks use the Base Station ID (BID). WCDMA networks use the UTRAN/GERAN Cell Identity
-   * (UC-Id), which is a 32-bit value concatenating the Radio Network Controller (RNC) and Cell ID.
-   * Specifying only the 16-bit Cell ID value in WCDMA networks may return inaccurate results.
+   * Unique identifier of the cell (required). On GSM, this is the Cell ID (CID); CDMA networks use
+   * the Base Station ID (BID). WCDMA networks use the UTRAN/GERAN Cell Identity (UC-Id), which is a
+   * 32-bit value concatenating the Radio Network Controller (RNC) and Cell ID. Specifying only the
+   * 16-bit Cell ID value in WCDMA networks may return inaccurate results.
    */
   public Integer cellId = null;
   /**
-   * {@code locationAreaCode} (required): The Location Area Code (LAC) for GSM and WCDMAnetworks.
-   * The Network ID (NID) for CDMA networks.
+   * The Location Area Code (LAC) for GSM and WCDMAnetworks or The Network ID (NID) for CDMA
+   * networks (required).
    */
   public Integer locationAreaCode = null;
-  /** {@code mobileCountryCode} (required): The cell tower's Mobile Country Code (MCC). */
+  /** The cell tower's Mobile Country Code (MCC) (required). */
   public Integer mobileCountryCode = null;
   /**
-   * {@code mobileNetworkCode} (required): The cell tower's Mobile Network Code. This is the MNC for
-   * GSM and WCDMA; CDMA uses the System ID (SID).
+   * The cell tower's Mobile Network Code (required). This is the MNC for GSM and WCDMA; CDMA uses
+   * the System ID (SID).
    */
   public Integer mobileNetworkCode = null;
   /* The following optional fields are not currently used, but may be included if values are available. */
   /**
-   * {@code age}: The number of milliseconds since this cell was primary. If age is 0, the cellId
-   * represents a current measurement.
+   * The number of milliseconds since this cell was primary. If age is 0, the cellId represents a
+   * current measurement.
    */
   public Integer age = null;
-  /** {@code signalStrength}: Radio signal strength measured in dBm. */
+  /** Radio signal strength measured in dBm. */
   public Integer signalStrength = null;
-  /** {@code timingAdvance}: The timing advance value. */
+  /** The timing advance value. */
   public Integer timingAdvance = null;
 
   public static class CellTowerBuilder {

--- a/src/main/java/com/google/maps/model/ComponentFilter.java
+++ b/src/main/java/com/google/maps/model/ComponentFilter.java
@@ -20,9 +20,9 @@ import static com.google.maps.internal.StringJoin.join;
 import com.google.maps.internal.StringJoin;
 
 /**
- * This class represents a component filter for a geocode request. In a geocoding response, the
- * Google Geocoding API can return address results restricted to a specific area. The restriction is
- * specified using the components filter.
+ * A component filter for a geocode request. In a geocoding response, the Google Geocoding API can
+ * return address results restricted to a specific area. The restriction is specified using the
+ * components filter.
  *
  * <p>Please see <a
  * href="https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering">Component
@@ -33,7 +33,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   public final String value;
 
   /**
-   * Construct a component filter.
+   * Constructs a component filter.
    *
    * @param component The component to filter.
    * @param value The value of the filter.
@@ -54,7 +54,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   }
 
   /**
-   * {@code route} matches long or short name of a route.
+   * Matches long or short name of a route.
    *
    * @param route The name of the route to filter on.
    * @return Returns a {@link ComponentFilter}.
@@ -64,7 +64,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   }
 
   /**
-   * {@code locality} matches against both locality and sublocality types.
+   * Matches against both locality and sublocality types.
    *
    * @param locality The locality to filter on.
    * @return Returns a {@link ComponentFilter}.
@@ -74,7 +74,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   }
 
   /**
-   * {@code administrativeArea} matches all the administrative area levels.
+   * Matches all the administrative area levels.
    *
    * @param administrativeArea The administrative area to filter on.
    * @return Returns a {@link ComponentFilter}.
@@ -84,7 +84,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   }
 
   /**
-   * {@code postalCode} matches postal code and postal code prefix.
+   * Matches postal code or postal code prefix.
    *
    * @param postalCode The postal code to filter on.
    * @return Returns a {@link ComponentFilter}.
@@ -94,7 +94,7 @@ public class ComponentFilter implements StringJoin.UrlValue {
   }
 
   /**
-   * {@code country} matches a country name or a two letter ISO 3166-1 country code.
+   * Matches a country name or a two letter ISO 3166-1 country code.
    *
    * @param country The country to filter on.
    * @return Returns a {@link ComponentFilter}.


### PR DESCRIPTION
This rephrases several Javadoc elements to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide. In particular, the guide calls for:

> Each Javadoc block begins with a brief summary fragment. This fragment is very important: it is the only part of the text that appears in certain contexts such as class and method indexes.
>
> This is a fragment—a noun phrase or verb phrase, not a complete sentence. It does not begin with A {@code Foo} is a..., or This method returns..., nor does it form a complete imperative sentence like Save the record.. However, the fragment is capitalized and punctuated as if it were a complete sentence.

I've broken this out in to multiple PRs, alphabetically by class name, to make it easier to review, and to save myself some work if you decide you don't want to do this rephrasing.

I've also removed "indicates" from most of the summaries as being redundant, since "indicating" is all that data values do.