### PR TITLE
Use Oxford commas in Javadoc

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -26,8 +26,8 @@ import com.google.maps.model.GeocodedWaypoint;
 /**
  * The Google Directions API is a service that calculates directions between locations using an HTTP
  * request. You can search for directions for several modes of transportation, include transit,
- * driving, walking or cycling. Directions may specify origins, destinations and waypoints either as
- * text strings (e.g. "Chicago, IL" or "Darwin, NT, Australia") or as latitude/longitude
+ * driving, walking, or cycling. Directions may specify origins, destinations, and waypoints, either
+ * as text strings (e.g. "Chicago, IL" or "Darwin, NT, Australia") or as latitude/longitude
  * coordinates. The Directions API can return multi-part directions using a series of waypoints.
  *
  * <p>See <a href="https://developers.google.com/maps/documentation/directions/intro">the Directions

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -39,7 +39,7 @@ public class DistanceMatrixElement {
    *
    * <ol>
    *   <li>The request includes a departureTime parameter.
-   *   <li>The request includes a valid API key, or a valid Google Maps APIs Premium Plan client ID
+   *   <li>The request includes a valid API key or a valid Google Maps APIs Premium Plan client ID
    *       and signature.
    *   <li>Traffic conditions are available for the requested route.
    *   <li>The mode parameter is set to driving.

--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -21,7 +21,7 @@ import org.joda.time.Instant;
 /**
  * PlaceDetails is the result of a Place Details request. A Place Details request returns more
  * comprehensive information about the indicated place such as its complete address, phone number,
- * user rating and reviews.
+ * user rating, and reviews.
  *
  * <p>See <a href="https://developers.google.com/places/web-service/details#PlaceDetailsResults">
  * Place Details Results</a> for more detail.

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -21,8 +21,8 @@ import org.joda.time.DateTime;
  * Transit directions return additional information that is not relevant for other modes of
  * transportation. These additional properties are exposed through the {@code TransitDetails}
  * object, returned as a field of an element in the {@code steps} array. From the {@code
- * TransitDetails} object you can access additional information about the transit stop, transit line
- * and transit agency.
+ * TransitDetails} object you can access additional information about the transit stop, transit
+ * line, and transit agency.
  */
 public class TransitDetails {
 


### PR DESCRIPTION
Per [@sarahmaddox's comment](https://github.com/googlemaps/google-maps-services-java/issues/312#issuecomment-321104028), prose in this project should use Oxford commas.

I noticed some locations in the Javadoc that were not using Oxford commas. This PR updates those locations to use them.