### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes D-F)

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -88,13 +88,13 @@ public class DirectionsApi {
    */
   public enum RouteRestriction implements UrlValue {
 
-    /** {@code TOLLS} indicates that the calculated route should avoid toll roads/bridges. */
+    /** Indicates that the calculated route should avoid toll roads/bridges. */
     TOLLS("tolls"),
 
-    /** {@code HIGHWAYS} indicates that the calculated route should avoid highways. */
+    /** Indicates that the calculated route should avoid highways. */
     HIGHWAYS("highways"),
 
-    /** {@code FERRIES} indicates that the calculated route should avoid ferries. */
+    /** Indicates that the calculated route should avoid ferries. */
     FERRIES("ferries");
 
     private final String restriction;

--- a/src/main/java/com/google/maps/ElevationApi.java
+++ b/src/main/java/com/google/maps/ElevationApi.java
@@ -39,7 +39,7 @@ public class ElevationApi {
   private ElevationApi() {}
 
   /**
-   * Get a list of elevations for a list of points.
+   * Gets a list of elevations for a list of points.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param points The points to retrieve elevations for.
@@ -100,7 +100,7 @@ public class ElevationApi {
   }
 
   /**
-   * Retrieve the elevation of a single location.
+   * Retrieves the elevation of a single location.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param location The location to retrieve the elevation for.
@@ -135,7 +135,7 @@ public class ElevationApi {
   }
 
   /**
-   * Retrieve the elevations of an encoded polyline path.
+   * Retrieves the elevations of an encoded polyline path.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param encodedPolyline The encoded polyline to retrieve elevations for.

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -35,14 +35,10 @@ public enum AddressType implements UrlValue {
   /** A major intersection, usually of two major roads. */
   INTERSECTION("intersection"),
 
-  /**
-   * A political entity. Usually, this type indicates a polygon of some civil administration.
-   */
+  /** A political entity. Usually, this type indicates a polygon of some civil administration. */
   POLITICAL("political"),
 
-  /**
-   * The national political entity, typically the highest order type returned by the Geocoder.
-   */
+  /** The national political entity, typically the highest order type returned by the Geocoder. */
   COUNTRY("country"),
 
   /**
@@ -88,10 +84,9 @@ public enum AddressType implements UrlValue {
   WARD("ward"),
 
   /**
-   * A first-order civil entity below a locality. Some locations may receive one of the
-   * additional types: {@code SUBLOCALITY_LEVEL_1} to {@code
-   * SUBLOCALITY_LEVEL_5}. Each sublocality level is a civil entity. Larger numbers indicate a
-   * smaller geographic area.
+   * A first-order civil entity below a locality. Some locations may receive one of the additional
+   * types: {@code SUBLOCALITY_LEVEL_1} to {@code SUBLOCALITY_LEVEL_5}. Each sublocality level is a
+   * civil entity. Larger numbers indicate a smaller geographic area.
    */
   SUBLOCALITY("sublocality"),
   SUBLOCALITY_LEVEL_1("sublocality_level_1"),
@@ -103,9 +98,7 @@ public enum AddressType implements UrlValue {
   /** A named neighborhood. */
   NEIGHBORHOOD("neighborhood"),
 
-  /**
-   * A named location, usually a building or collection of buildings with a common name.
-   */
+  /** A named location, usually a building or collection of buildings with a common name. */
   PREMISE("premise"),
 
   /**
@@ -114,14 +107,10 @@ public enum AddressType implements UrlValue {
    */
   SUBPREMISE("subpremise"),
 
-  /**
-   * A postal code as used to address postal mail within the country.
-   */
+  /** A postal code as used to address postal mail within the country. */
   POSTAL_CODE("postal_code"),
 
-  /**
-   * A postal code prefix as used to address postal mail within the country.
-   */
+  /** A postal code prefix as used to address postal mail within the country. */
   POSTAL_CODE_PREFIX("postal_code_prefix"),
 
   /** A prominent natural feature. */

--- a/src/main/java/com/google/maps/model/AutocompletePrediction.java
+++ b/src/main/java/com/google/maps/model/AutocompletePrediction.java
@@ -62,14 +62,12 @@ public class AutocompletePrediction {
   public MatchedSubstring matchedSubstrings[];
 
   /**
-   * Identifies each section of the returned description. (A section of the description is
-   * generally terminated with a comma.)
+   * Identifies each section of the returned description. (A section of the description is generally
+   * terminated with a comma.)
    */
   public static class Term {
 
-    /**
-     * The start position of this term in the description, measured in Unicode characters.
-     */
+    /** The start position of this term in the description, measured in Unicode characters. */
     public int offset;
 
     /** The text of the matched term. */

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -26,21 +26,20 @@ import org.joda.time.DateTime;
 public class DirectionsLeg {
 
   /**
-   * {@code steps[]} contains an array of steps denoting information about each separate step of the
-   * leg of the journey.
+   * Contains an array of steps denoting information about each separate step of this leg of the
+   * journey.
    */
   public DirectionsStep[] steps;
 
-  /** {@code distance} indicates the total distance covered by this leg. */
+  /** The total distance covered by this leg. */
   public Distance distance;
 
-  /** {@code duration} indicates the total duration of this leg */
+  /** The total duration of this leg. */
   public Duration duration;
 
   /**
-   * {@code durationInTraffic} indicates the total duration of this leg, taking into account current
-   * traffic conditions. The duration in traffic will only be returned if all of the following are
-   * true:
+   * The total duration of this leg, taking into account current traffic conditions. The duration in
+   * traffic will only be returned if all of the following are true:
    *
    * <ol>
    *   <li>The directions request includes a departureTime parameter set to a value within a few
@@ -53,43 +52,42 @@ public class DirectionsLeg {
   public Duration durationInTraffic;
 
   /**
-   * {@code arrivalTime} contains the estimated time of arrival for this leg. This property is only
-   * returned for transit directions.
+   * The estimated time of arrival for this leg. This property is only returned for transit
+   * directions.
    */
   public DateTime arrivalTime;
 
   /**
-   * {@code departureTime} contains the estimated time of departure for this leg. The departureTime
-   * is only available for transit directions.
+   * The estimated time of departure for this leg. The departureTime is only available for transit
+   * directions.
    */
   public DateTime departureTime;
 
   /**
-   * {@code startLocation} contains the latitude/longitude coordinates of the origin of this leg.
-   * Because the Directions API calculates directions between locations by using the nearest
-   * transportation option (usually a road) at the start and end points, startLocation may be
-   * different than the provided origin of this leg if, for example, a road is not near the origin.
+   * The latitude/longitude coordinates of the origin of this leg. Because the Directions API
+   * calculates directions between locations by using the nearest transportation option (usually a
+   * road) at the start and end points, startLocation may be different from the provided origin of
+   * this leg if, for example, a road is not near the origin.
    */
   public LatLng startLocation;
 
   /**
-   * {@code endLocation} contains the latitude/longitude coordinates of the given destination of
-   * this leg. Because the Directions API calculates directions between locations by using the
-   * nearest transportation option (usually a road) at the start and end points, endLocation may be
-   * different than the provided destination of this leg if, for example, a road is not near the
-   * destination.
+   * The latitude/longitude coordinates of the given destination of this leg. Because the Directions
+   * API calculates directions between locations by using the nearest transportation option (usually
+   * a road) at the start and end points, endLocation may be different than the provided destination
+   * of this leg if, for example, a road is not near the destination.
    */
   public LatLng endLocation;
 
   /**
-   * {@code startAddress} contains the human-readable address (typically a street address)
-   * reflecting the start location of this leg.
+   * The human-readable address (typically a street address) reflecting the start location of this
+   * leg.
    */
   public String startAddress;
 
   /**
-   * {@code endAddress} contains the human-readable address (typically a street address) reflecting
-   * the end location of this leg.
+   * The human-readable address (typically a street address) reflecting the end location of this
+   * leg.
    */
   public String endAddress;
 }

--- a/src/main/java/com/google/maps/model/DirectionsResult.java
+++ b/src/main/java/com/google/maps/model/DirectionsResult.java
@@ -24,15 +24,14 @@ package com.google.maps.model;
 public class DirectionsResult {
 
   /**
-   * {@code geocodedWaypoints} contains an array with details about the geocoding of origin,
-   * destination and waypoints. See <a
+   * Details about the geocoding of origin, destination, and waypoints. See <a
    * href="https://developers.google.com/maps/documentation/directions/intro#GeocodedWaypoints">
    * Geocoded Waypoints</a> for more detail.
    */
   public GeocodedWaypoint geocodedWaypoints[];
 
   /**
-   * {@code routes} contains an array of routes from the origin to the destination. See <a
+   * Routes from the origin to the destination. See <a
    * href="https://developers.google.com/maps/documentation/directions/intro#Routes">Routes</a> for
    * more detail.
    */

--- a/src/main/java/com/google/maps/model/DirectionsRoute.java
+++ b/src/main/java/com/google/maps/model/DirectionsRoute.java
@@ -25,50 +25,46 @@ package com.google.maps.model;
  */
 public class DirectionsRoute {
   /**
-   * {@code summary} contains a short textual description for the route, suitable for naming and
-   * disambiguating the route from alternatives.
+   * A short textual description for the route, suitable for naming and disambiguating the route
+   * from alternatives.
    */
   public String summary;
 
   /**
-   * {@code legs} contains information about a leg of the route, between two locations within the
-   * given route. A separate leg will be present for each waypoint or destination specified. (A
-   * route with no waypoints will contain exactly one leg within the legs array.)
+   * Information about legs of the route, between locations within the route. A separate leg will be
+   * present for each waypoint or destination specified. (A route with no waypoints will contain
+   * exactly one leg within the legs array.)
    */
   public DirectionsLeg[] legs;
 
   /**
-   * {@code waypointOrder} contains an array indicating the order of any waypoints in the calculated
-   * route. This waypoints may be reordered if the request was passed {@code optimize:true} within
-   * its {@code waypoints} parameter.
+   * Indicates the order of any waypoints in the calculated route. This waypoints may be reordered
+   * if the request was passed {@code optimize:true} within its {@code waypoints} parameter.
    */
   public int[] waypointOrder;
 
-  /**
-   * {@code overviewPolyline} contains an object holding an array of encoded points that represent
-   * an approximate (smoothed) path of the resulting directions.
-   */
+  /** An approximate (smoothed) path of the resulting directions. */
   public EncodedPolyline overviewPolyline;
 
-  /** {@code bounds} contains the viewport bounding box of the overview_polyline. */
+  /** The viewport bounding box of the overview_polyline. */
   public Bounds bounds;
 
   /**
-   * {@code copyrights} contains the copyrights text to be displayed for this route. You must handle
-   * and display this information yourself.
+   * Copyrights text to be displayed for this route. You must handle and display this information
+   * yourself.
    */
   public String copyrights;
 
   /**
-   * {@code fare} contains information about the fare (that is, the ticket costs) on this route.
-   * This property is only returned for transit directions, and only for routes where fare
-   * information is available for all transit legs.
+   * Information about the fare (that is, the ticket costs) on this route. This property is only
+   * returned for transit directions, and only for routes where fare information is available for
+   * all transit legs.
    */
   public Fare fare;
 
   /**
-   * {@code warnings} contains an array of warnings to be displayed when showing these directions.
-   * You must handle and display these warnings yourself.
+   * Warnings to be displayed when showing these directions. You must handle and display these
+   * warnings yourself.
    */
   public String[] warnings;
 }

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -36,51 +36,46 @@ package com.google.maps.model;
  */
 public class DirectionsStep {
 
-  /**
-   * {@code htmlInstructions} contains formatted instructions for this step, presented as an HTML
-   * text string.
-   */
+  /** Formatted instructions for this step, presented as an HTML text string. */
   public String htmlInstructions;
 
-  /** {@code distance} contains the distance covered by this step until the next step. */
+  /** The distance covered by this step until the next step. */
   public Distance distance;
 
   /**
-   * {@code maneuver} contains the maneuver required to move ahead. E.g., turn-left. Please note,
-   * this field is undocumented, and thus should not be relied upon.
+   * The maneuver required to move ahead. E.g., turn-left. Please note, this field is undocumented,
+   * and thus should not be relied upon.
    */
   @Deprecated public String maneuver;
 
-  /**
-   * {@code duration} contains the typical time required to perform the step, until the next step.
-   */
+  /** The typical time required to perform the step, until the next step. */
   public Duration duration;
 
-  /** {@code startLocation} contains the location of the starting point of this step. */
+  /** The location of the starting point of this step. */
   public LatLng startLocation;
 
-  /** {@code endLocation} contains the location of the last point of this step. */
+  /** The location of the last point of this step. */
   public LatLng endLocation;
 
   /**
-   * {@code steps} contains detailed directions for walking or driving steps in transit directions.
-   * Substeps are only available when travelMode is set to "transit".
+   * Detailed directions for walking or driving steps in transit directions. Substeps are only
+   * available when travelMode is set to "transit".
    */
   public DirectionsStep[] steps;
 
-  /** {@code polyline} is the path of this step. */
+  /** The path of this step. */
   public EncodedPolyline polyline;
 
   /**
-   * {@code travelMode} is the travel mode of this step. See <a
+   * The travel mode of this step. See <a
    * href="https://developers.google.com/maps/documentation/directions/intro#TravelModes">Travel
    * Modes</a> for more detail.
    */
   public TravelMode travelMode;
 
   /**
-   * {@code transitDetails} contains transit specific information. This field is only returned with
-   * travel_mode is set to "transit". See <a
+   * Transit-specific information. This field is only returned when travel_mode is set to "transit".
+   * See <a
    * href="https://developers.google.com/maps/documentation/directions/intro#TransitDetails">Transit
    * Details</a> for more detail.
    */

--- a/src/main/java/com/google/maps/model/Distance.java
+++ b/src/main/java/com/google/maps/model/Distance.java
@@ -19,14 +19,14 @@ package com.google.maps.model;
 public class Distance {
 
   /**
-   * This is the numeric distance, always in meters. This is intended to be used only in algorithmic
-   * situations, e.g. sorting results by some user specified metric.
+   * The numeric distance, in meters. This is intended to be used only in algorithmic situations,
+   * e.g. sorting results by some user specified metric.
    */
   public long inMeters;
 
   /**
-   * This is the human friendly distance. This is rounded and in an appropriate unit for the
-   * request. The units can be overridden with a request parameter.
+   * The human-friendly distance. This is rounded and in an appropriate unit for the request. The
+   * units can be overridden with a request parameter.
    */
   public String humanReadable;
 

--- a/src/main/java/com/google/maps/model/DistanceMatrix.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrix.java
@@ -25,21 +25,19 @@ package com.google.maps.model;
 public class DistanceMatrix {
 
   /**
-   * {@code originAddresses} contains an array of addresses as returned by the API from your
-   * original request. These are formatted by the geocoder and localized according to the language
-   * parameter passed with the request.
+   * Origin addresses as returned by the API from your original request. These are formatted by the
+   * geocoder and localized according to the language parameter passed with the request.
    */
   public final String[] originAddresses;
 
   /**
-   * {@code destinationAddresses} contains an array of addresses as returned by the API from your
-   * original request. As with {@link #originAddresses}, these are localized if appropriate.
+   * Destination addresses as returned by the API from your original request. As with {@link
+   * #originAddresses}, these are localized if appropriate.
    */
   public final String[] destinationAddresses;
 
   /**
-   * {@code rows} contains an array of elements, which in turn each contain a status, duration, and
-   * distance element.
+   * An array of elements, each of which in turn contains a status, duration, and distance element.
    */
   public final DistanceMatrixRow[] rows;
 

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -24,19 +24,18 @@ package com.google.maps.model;
 public class DistanceMatrixElement {
 
   /**
-   * {@code status} indicates the status of the request for this origin/destination pair.
+   * The status of the request for this origin/destination pair.
    *
    * <p>Will be one of {@link com.google.maps.model.DistanceMatrixElementStatus}.
    */
   public DistanceMatrixElementStatus status;
 
-  /** {@code duration} indicates the total duration of this leg. */
+  /** The total duration of this leg. */
   public Duration duration;
 
   /**
-   * {@code durationInTraffic} indicates the length of time to travel this route, based on current
-   * and historical traffic conditions. The duration in traffic will only be returned if all of the
-   * following are true:
+   * The length of time to travel this route, based on current and historical traffic conditions.
+   * The duration in traffic will only be returned if all of the following are true:
    *
    * <ol>
    *   <li>The request includes a departureTime parameter.

--- a/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElementStatus.java
@@ -23,17 +23,12 @@ package com.google.maps.model;
  *     Documentation on status codes</a>
  */
 public enum DistanceMatrixElementStatus {
-  /** {@code OK} indicates that the response contains a valid result. */
+  /** Indicates that the response contains a valid result. */
   OK,
 
-  /**
-   * {@code NOT_FOUND} indicates that the origin and/or destination of this pairing could not be
-   * geocoded.
-   */
+  /** Indicates that the origin and/or destination of this pairing could not be geocoded. */
   NOT_FOUND,
 
-  /**
-   * {@code ZERO_RESULTS} indicates that no route could be found between the origin and destination.
-   */
+  /** Indicates that no route could be found between the origin and destination. */
   ZERO_RESULTS
 }

--- a/src/main/java/com/google/maps/model/DistanceMatrixRow.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixRow.java
@@ -21,6 +21,6 @@ package com.google.maps.model;
  */
 public class DistanceMatrixRow {
 
-  /** {@code elements} contains the results for this row, or individual origin. */
+  /** The results for this row, or individual origin. */
   public DistanceMatrixElement[] elements;
 }

--- a/src/main/java/com/google/maps/model/Duration.java
+++ b/src/main/java/com/google/maps/model/Duration.java
@@ -19,12 +19,12 @@ package com.google.maps.model;
 public class Duration {
 
   /**
-   * This is the numeric duration, in seconds. This is intended to be used only in algorithmic
-   * situations, e.g. sorting results by some user specified metric.
+   * The numeric duration, in seconds. This is intended to be used only in algorithmic situations,
+   * e.g. sorting results by some user specified metric.
    */
   public long inSeconds;
 
-  /** This is the human friendly duration. Use this for display purposes. */
+  /** The human-friendly duration. Use this for display purposes. */
   public String humanReadable;
 
   @Override

--- a/src/main/java/com/google/maps/model/Fare.java
+++ b/src/main/java/com/google/maps/model/Fare.java
@@ -26,13 +26,9 @@ import java.util.Currency;
  */
 public class Fare {
 
-  /**
-   * {@code currency} contains the currency indicating the currency that the amount is expressed in.
-   */
+  /** The currency that the amount is expressed in. */
   public Currency currency;
 
-  /**
-   * {@code value} contains the total fare amount, in the currency specified in {@link #currency}.
-   */
+  /** The total fare amount, in the currency specified in {@link #currency}. */
   public BigDecimal value;
 }


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

This PR covers classes with names starting with D-F.

Follows up #315.