### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes G)

### DIFF
--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -74,9 +74,9 @@ public class GeoApiContext {
   }
 
   /**
-   * RequestHandler is the service provider interface that enables requests to be handled via
-   * switchable back ends. There are supplied implementations of this interface for both OkHttp and
-   * Google App Engine's URL Fetch API.
+   * The service provider interface that enables requests to be handled via switchable back ends.
+   * There are supplied implementations of this interface for both OkHttp and Google App Engine's
+   * URL Fetch API.
    *
    * @see OkHttpRequestHandler
    * @see GaeRequestHandler
@@ -104,6 +104,7 @@ public class GeoApiContext {
         Integer maxRetries,
         ExceptionsAllowedToRetry exceptionsAllowedToRetry);
 
+    /** Builder pattern for {@code GeoApiContext.RequestHandler}. */
     interface Builder {
 
       void connectTimeout(long timeout, TimeUnit unit);
@@ -273,7 +274,7 @@ public class GeoApiContext {
     }
   }
 
-  /** This is the Builder for {@code GeoApiContext}. */
+  /** The Builder for {@code GeoApiContext}. */
   public static class Builder {
 
     private RequestHandler.Builder builder;
@@ -297,8 +298,8 @@ public class GeoApiContext {
     }
 
     /**
-     * Change the RequestHandler.Builder strategy to change between the {@code OkHttpRequestHandler}
-     * and the {@code GaeRequestHandler}.
+     * Changes the RequestHandler.Builder strategy to change between the {@code
+     * OkHttpRequestHandler} and the {@code GaeRequestHandler}.
      *
      * @param builder The {@code RequestHandler.Builder} to use for {@link #build()}
      * @return Returns this builder for call chaining.
@@ -312,7 +313,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Override the base URL of the API endpoint. Useful only for testing.
+     * Overrides the base URL of the API endpoint. Useful only for testing.
      *
      * @param baseUrl The URL to use, without a trailing slash, e.g. https://maps.googleapis.com
      * @return Returns this builder for call chaining.
@@ -323,7 +324,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Set the API Key to use for authorizing requests.
+     * Sets the API Key to use for authorizing requests.
      *
      * @param apiKey The API Key to use.
      * @return Returns this builder for call chaining.
@@ -334,7 +335,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Set the ClientID/Secret pair to use for authorizing requests.
+     * Sets the ClientID/Secret pair to use for authorizing requests.
      *
      * @param clientId The Client ID to use.
      * @param cryptographicSecret The Secret to use.
@@ -430,7 +431,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Disable retries completely, by setting max retries to 0 and retry timeout to 0.
+     * Disables retries completely, by setting max retries to 0 and retry timeout to 0.
      *
      * @return Returns this builder for call chaining.
      */
@@ -482,7 +483,7 @@ public class GeoApiContext {
     }
 
     /**
-     * Convert this builder into a {@code GeoApiContext}.
+     * Converts this builder into a {@code GeoApiContext}.
      *
      * @return Returns the built {@code GeoApiContext}.
      */

--- a/src/main/java/com/google/maps/GeocodingApi.java
+++ b/src/main/java/com/google/maps/GeocodingApi.java
@@ -33,7 +33,7 @@ public class GeocodingApi {
   private GeocodingApi() {}
 
   /**
-   * Create a new Geocoding API request.
+   * Creates a new Geocoding API request.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @return Returns the request, ready to run.
@@ -43,7 +43,7 @@ public class GeocodingApi {
   }
 
   /**
-   * Request the latitude and longitude of an {@code address}.
+   * Requests the latitude and longitude of an {@code address}.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param address The address to geocode.
@@ -56,7 +56,7 @@ public class GeocodingApi {
   }
 
   /**
-   * Request the street address of a {@code location}.
+   * Requests the street address of a {@code location}.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param location The location to reverse geocode.

--- a/src/main/java/com/google/maps/GeocodingApiRequest.java
+++ b/src/main/java/com/google/maps/GeocodingApiRequest.java
@@ -24,7 +24,7 @@ import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.LocationType;
 
-/** Request for the Geocoding API. */
+/** A request for the Geocoding API. */
 public class GeocodingApiRequest
     extends PendingResultBase<GeocodingResult[], GeocodingApiRequest, GeocodingApi.Response> {
 
@@ -55,7 +55,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Create a forward geocode for {@code address}.
+   * Creates a forward geocode for {@code address}.
    *
    * @param address The address to geocode.
    * @return Returns this {@code GeocodingApiRequest} for call chaining.
@@ -65,7 +65,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Create a forward geocode for {@code placeId}.
+   * Creates a forward geocode for {@code placeId}.
    *
    * @param placeId The Place ID to geocode.
    * @return Returns this {@code GeocodingApiRequest} for call chaining.
@@ -75,7 +75,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Create a reverse geocode for {@code latlng}.
+   * Creates a reverse geocode for {@code latlng}.
    *
    * @param latlng The location to reverse geocode.
    * @return Returns this {@code GeocodingApiRequest} for call chaining.
@@ -85,7 +85,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Set the bounding box of the viewport within which to bias geocode results more prominently.
+   * Sets the bounding box of the viewport within which to bias geocode results more prominently.
    * This parameter will only influence, not fully restrict, results from the geocoder.
    *
    * <p>For more information see <a
@@ -101,7 +101,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Set the region code, specified as a ccTLD ("top-level domain") two-character value. This
+   * Sets the region code, specified as a ccTLD ("top-level domain") two-character value. This
    * parameter will only influence, not fully restrict, results from the geocoder.
    *
    * <p>For more information see <a
@@ -116,7 +116,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Set the component filters. Each component filter consists of a component:value pair and will
+   * Sets the component filters. Each component filter consists of a component:value pair and will
    * fully restrict the results from the geocoder.
    *
    * <p>For more information see <a
@@ -131,7 +131,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Set the result type. Specifying a type will restrict the results to this type. If multiple
+   * Sets the result type. Specifying a type will restrict the results to this type. If multiple
    * types are specified, the API will return all addresses that match any of the types.
    *
    * @param resultTypes The result types to restrict to.
@@ -142,7 +142,7 @@ public class GeocodingApiRequest
   }
 
   /**
-   * Set the location type. Specifying a type will restrict the results to this type. If multiple
+   * Sets the location type. Specifying a type will restrict the results to this type. If multiple
    * types are specified, the API will return all addresses that match any of the types.
    *
    * @param locationTypes The location types to restrict to.

--- a/src/main/java/com/google/maps/GeolocationApiRequest.java
+++ b/src/main/java/com/google/maps/GeolocationApiRequest.java
@@ -22,7 +22,7 @@ import com.google.maps.model.GeolocationPayload.GeolocationPayloadBuilder;
 import com.google.maps.model.GeolocationResult;
 import com.google.maps.model.WifiAccessPoint;
 
-/** Request for the Geolocation API. */
+/** A request for the Geolocation API. */
 public class GeolocationApiRequest
     extends PendingResultBase<GeolocationResult, GeolocationApiRequest, GeolocationApi.Response> {
 

--- a/src/main/java/com/google/maps/model/GeocodedWaypoint.java
+++ b/src/main/java/com/google/maps/model/GeocodedWaypoint.java
@@ -16,27 +16,24 @@
 package com.google.maps.model;
 
 /**
- * Geocoded Waypoint represents a point in a Directions API response, either the origin, one of the
- * requested waypoints, or the destination. Please see <a
+ * A point in a Directions API response; either the origin, one of the requested waypoints, or the
+ * destination. Please see <a
  * href="https://developers.google.com/maps/documentation/directions/intro#GeocodedWaypoints">
  * Geocoded Waypoints</a> for more detail.
  */
 public class GeocodedWaypoint {
-  /** {@code geocoderStatus} indicates the status code resulting from the geocoding operation. */
+  /** The status code resulting from the geocoding operation for this waypoint. */
   public GeocodedWaypointStatus geocoderStatus;
 
   /**
-   * {@code partialMatch} indicates that the geocoder did not return an exact match for the original
-   * request, though it was able to match part of the requested address.
+   * Indicates that the geocoder did not return an exact match for the original request, though it
+   * was able to match part of the requested address.
    */
   public boolean partialMatch;
 
-  /** {@code placeId} is a unique identifier that can be used with other Google APIs. */
+  /** A unique identifier for this waypoint that can be used with other Google APIs. */
   public String placeId;
 
-  /**
-   * {@code types} indicates the address type of the geocoding result used for calculating
-   * directions.
-   */
+  /** The address types of the geocoding result used for calculating directions. */
   public AddressType types[];
 }

--- a/src/main/java/com/google/maps/model/GeocodedWaypointStatus.java
+++ b/src/main/java/com/google/maps/model/GeocodedWaypointStatus.java
@@ -22,9 +22,9 @@ package com.google.maps.model;
  *     Documentation on status codes</a>
  */
 public enum GeocodedWaypointStatus {
-  /** {@code OK} indicates the response contains a valid result. */
+  /** Indicates the response contains a valid result. */
   OK,
 
-  /** {@code ZERO_RESULTS} indicates no route could be found between the origin and destination. */
+  /** Indicates no route could be found between the origin and destination. */
   ZERO_RESULTS
 }

--- a/src/main/java/com/google/maps/model/GeocodingResult.java
+++ b/src/main/java/com/google/maps/model/GeocodingResult.java
@@ -15,44 +15,46 @@
 
 package com.google.maps.model;
 
-/** Result from a Geocoding API call. */
+/** A result from a Geocoding API call. */
 public class GeocodingResult {
 
-  /** {@code addressComponents} is an array containing the separate address components. */
+  /** The separate address components in this result. */
   public AddressComponent[] addressComponents;
 
   /**
-   * {@code formattedAddress} is the human-readable address of this location. Often this address is
-   * equivalent to the "postal address," which sometimes differs from country to country. (Note that
-   * some countries, such as the United Kingdom, do not allow distribution of true postal addresses
-   * due to licensing restrictions.) This address is generally composed of one or more address
-   * components. For example, the address "111 8th Avenue, New York, NY" contains separate address
-   * components for "111" (the street number, "8th Avenue" (the route), "New York" (the city) and
-   * "NY" (the US state). These address components contain additional information.
+   * The human-readable address of this location.
+   *
+   * <p>Often this address is equivalent to the "postal address," which sometimes differs from
+   * country to country. (Note that some countries, such as the United Kingdom, do not allow
+   * distribution of true postal addresses due to licensing restrictions.) This address is generally
+   * composed of one or more address components. For example, the address "111 8th Avenue, New York,
+   * NY" contains separate address components for "111" (the street number, "8th Avenue" (the
+   * route), "New York" (the city) and "NY" (the US state). These address components contain
+   * additional information.
    */
   public String formattedAddress;
 
   /**
-   * {@code postcodeLocalities} is an array denoting all the localities contained in a postal code.
-   * This is only present when the result is a postal code that contains multiple localities.
+   * All the localities contained in a postal code. This is only present when the result is a postal
+   * code that contains multiple localities.
    */
   public String[] postcodeLocalities;
 
-  /** {@code geometry} contains location information. */
+  /** Location information for this result. */
   public Geometry geometry;
 
   /**
-   * The {@code types} array indicates the type of the returned result. This array contains a set of
-   * zero or more tags identifying the type of feature returned in the result. For example, a
-   * geocode of "Chicago" returns "locality" which indicates that "Chicago" is a city, and also
-   * returns "political" which indicates it is a political entity.
+   * The types of the returned result. This array contains a set of zero or more tags identifying
+   * the type of feature returned in the result. For example, a geocode of "Chicago" returns
+   * "locality" which indicates that "Chicago" is a city, and also returns "political" which
+   * indicates it is a political entity.
    */
   public AddressType[] types;
 
   /**
-   * {@code partialMatch} indicates that the geocoder did not return an exact match for the original
-   * request, though it was able to match part of the requested address. You may wish to examine the
-   * original request for misspellings and/or an incomplete address.
+   * Indicates that the geocoder did not return an exact match for the original request, though it
+   * was able to match part of the requested address. You may wish to examine the original request
+   * for misspellings and/or an incomplete address.
    *
    * <p>Partial matches most often occur for street addresses that do not exist within the locality
    * you pass in the request. Partial matches may also be returned when a request matches two or
@@ -63,6 +65,6 @@ public class GeocodingResult {
    */
   public boolean partialMatch;
 
-  /** {@code placeId} is a unique identifier for a place. */
+  /** A unique identifier for this place. */
   public String placeId;
 }

--- a/src/main/java/com/google/maps/model/GeolocationPayload.java
+++ b/src/main/java/com/google/maps/model/GeolocationPayload.java
@@ -49,33 +49,27 @@ public class GeolocationPayload {
     cellTowers = _cellTowers;
     wifiAccessPoints = _wifiAccessPoints;
   }
-  /** {@code homeMobileCountryCode}: The mobile country code (MCC) for the device's home network. */
+  /** The mobile country code (MCC) for the device's home network. */
   public Integer homeMobileCountryCode = null;
-  /** {@code homeMobileNetworkCode}: The mobile network code (MNC) for the device's home network. */
+  /** The mobile network code (MNC) for the device's home network. */
   public Integer homeMobileNetworkCode = null;
   /**
-   * {@code radioType}: The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While
-   * this field is optional, it should be included if a value is available, for more accurate
-   * results.
+   * The mobile radio type. Supported values are {@code "lte"}, {@code "gsm"}, {@code "cdma"}, and
+   * {@code "wcdma"}. While this field is optional, it should be included if a value is available,
+   * for more accurate results.
    */
   public String radioType = null;
-  /** {@code carrier}: The carrier name. */
+  /** The carrier name. */
   public String carrier = null;
   /**
-   * {@code considerIp}: Specifies whether to fall back to IP geolocation if wifi and cell tower
-   * signals are not available. Note that the IP address in the request header may not be the IP of
-   * the device. Defaults to true. Set considerIp to false to disable fall back.
+   * Specifies whether to fall back to IP geolocation if wifi and cell tower signals are not
+   * available. Note that the IP address in the request header may not be the IP of the device.
+   * Defaults to true. Set considerIp to false to disable fall back.
    */
   public Boolean considerIp = null;
-  /**
-   * {@code cellTowers}: An array of cell tower objects. See {@link
-   * com.google.maps.model.CellTower}.
-   */
+  /** An array of cell tower objects. See {@link com.google.maps.model.CellTower}. */
   public CellTower[] cellTowers;
-  /**
-   * {@code wifiAccessPoints}: An array of WiFi access point objects. See {@link
-   * com.google.maps.model.WifiAccessPoint}.
-   */
+  /** An array of WiFi access point objects. See {@link com.google.maps.model.WifiAccessPoint}. */
   public WifiAccessPoint[] wifiAccessPoints;
 
   public static class GeolocationPayloadBuilder {

--- a/src/main/java/com/google/maps/model/GeolocationResult.java
+++ b/src/main/java/com/google/maps/model/GeolocationResult.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 /**
- * Geolocation Results.
+ * A Geolocation API result.
  *
  * <p>A successful geolocation request will return a result defining a location and radius.
  *
@@ -25,14 +25,11 @@ package com.google.maps.model;
  * responses</a> for more detail.
  */
 public class GeolocationResult {
-  /**
-   * {@code location}: The user’s estimated latitude and longitude, in degrees. Contains one lat and
-   * one lng subfield.
-   */
+  /** The user’s estimated latitude and longitude. */
   public LatLng location;
   /**
-   * {@code accuracy}: The accuracy of the estimated location, in meters. This represents the radius
-   * of a circle around the given {@code location}.
+   * The accuracy of the estimated location, in meters. This represents the radius of a circle
+   * around the returned {@code location}.
    */
   public double accuracy;
 }

--- a/src/main/java/com/google/maps/model/Geometry.java
+++ b/src/main/java/com/google/maps/model/Geometry.java
@@ -15,19 +15,19 @@
 
 package com.google.maps.model;
 
-/** The Geometry of a Geocoding Result. */
+/** The geometry of a Geocoding result. */
 public class Geometry {
   /**
-   * {@code bounds} (optionally returned) stores the bounding box which can fully contain the
-   * returned result. Note that these bounds may not match the recommended viewport. (For example,
-   * San Francisco includes the Farallon islands, which are technically part of the city, but
-   * probably should not be returned in the viewport.)
+   * The bounding box which can fully contain the returned result (optionally returned). Note that
+   * these bounds may not match the recommended viewport. (For example, San Francisco includes the
+   * Farallon islands, which are technically part of the city, but probably should not be returned
+   * in the viewport.)
    */
   public Bounds bounds;
 
   /**
-   * {@code location} contains the geocoded latitude/longitude value. For normal address lookups,
-   * this field is typically the most important.
+   * The geocoded latitude/longitude value. For normal address lookups, this field is typically the
+   * most important.
    */
   public LatLng location;
 
@@ -35,8 +35,8 @@ public class Geometry {
   public LocationType locationType;
 
   /**
-   * {@code viewport} contains the recommended viewport for displaying the returned result.
-   * Generally the viewport is used to frame a result when displaying it to a user.
+   * The recommended viewport for displaying the returned result. Generally the viewport is used to
+   * frame a result when displaying it to a user.
    */
   public Bounds viewport;
 }


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

This PR covers classes with names starting with G.

Follows up #315.