### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes H-O)

### DIFF
--- a/src/main/java/com/google/maps/NearbySearchRequest.java
+++ b/src/main/java/com/google/maps/NearbySearchRequest.java
@@ -41,7 +41,7 @@ public class NearbySearchRequest
           .fieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);
 
   /**
-   * Constructor for {@code NearbySearchRequest}.
+   * Constructs a new {@code NearbySearchRequest}.
    *
    * @param context The {@code GeoApiContext} to make requests through.
    */
@@ -50,7 +50,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * location is the latitude/longitude around which to retrieve place information.
+   * Specifies the latitude/longitude around which to retrieve place information.
    *
    * @param location The location to use as the center of the Nearby Search.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -60,9 +60,9 @@ public class NearbySearchRequest
   }
 
   /**
-   * radius defines the distance (in meters) within which to return place results. The maximum
-   * allowed radius is 50,000 meters. Note that radius must not be included if {@code
-   * rankby=DISTANCE} is specified.
+   * Specifies the distance (in meters) within which to return place results. The maximum allowed
+   * radius is 50,000 meters. Note that radius must not be included if {@code rankby=DISTANCE} is
+   * specified.
    *
    * @param distance The distance in meters around the {@link #location(LatLng)} to search.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -75,7 +75,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * rankby specifies the order in which results are listed.
+   * Specifies the order in which results are listed.
    *
    * @param ranking The rank by method.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -85,8 +85,8 @@ public class NearbySearchRequest
   }
 
   /**
-   * keyword is a term to be matched against all content that Google has indexed for this place,
-   * including but not limited to name, type, and address, as well as customer reviews and other
+   * Specifies a term to be matched against all content that Google has indexed for this place. This
+   * includes but is not limited to name, type, and address, as well as customer reviews and other
    * third-party content.
    *
    * @param keyword The keyword to search for.
@@ -97,7 +97,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * minPrice restricts to places that are at least this price level.
+   * Restricts to places that are at least this price level.
    *
    * @param priceLevel The price level to set as minimum.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -107,7 +107,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * maxPrice restricts to places that are at most this price level.
+   * Restricts to places that are at most this price level.
    *
    * @param priceLevel The price level to set as maximum.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -117,8 +117,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * name is one or more terms to be matched against the names of places, separated with a space
-   * character.
+   * Specifies one or more terms to be matched against the names of places, separated by spaces.
    *
    * @param name Search for Places with this name.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -128,7 +127,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * openNow returns only those places that are open for business at the time the query is sent.
+   * Restricts to only those places that are open for business at the time the query is sent.
    *
    * @param openNow Whether to restrict to places that are open.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -138,9 +137,9 @@ public class NearbySearchRequest
   }
 
   /**
-   * pageToken returns the next 20 results from a previously run search. Setting {@code pageToken}
-   * will execute a search with the same parameters used previously — all parameters other than
-   * {@code pageToken} will be ignored.
+   * Returns the next 20 results from a previously run search. Setting {@code pageToken} will
+   * execute a search with the same parameters used previously — all parameters other than {@code
+   * pageToken} will be ignored.
    *
    * @param nextPageToken The page token from a previous result.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -150,7 +149,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * type restricts the results to places matching the specified type.
+   * Restricts the results to places matching the specified type.
    *
    * @param type The {@link PlaceType} to restrict results to.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
@@ -160,7 +159,7 @@ public class NearbySearchRequest
   }
 
   /**
-   * type restricts the results to places matching the specified type. Provides support for multiple
+   * Restricts the results to places matching the specified type. Provides support for multiple
    * types.
    *
    * @param types The {@link PlaceType}s to restrict results to.

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -85,7 +85,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
         req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
-  /** Builder strategy for constructing {@code OkHTTPRequestHandler}. */
+  /** Builder strategy for constructing an {@code OkHTTPRequestHandler}. */
   public static class Builder implements GeoApiContext.RequestHandler.Builder {
     private final OkHttpClient.Builder builder;
     private final RateLimitExecutorService rateLimitExecutorService;

--- a/src/main/java/com/google/maps/errors/OverDailyLimitException.java
+++ b/src/main/java/com/google/maps/errors/OverDailyLimitException.java
@@ -15,7 +15,7 @@
 
 package com.google.maps.errors;
 
-/** Indicates that the requesting account has exceeded daily quota. */
+/** Indicates that the requesting account has exceeded its daily quota. */
 public class OverDailyLimitException extends ApiException {
 
   public OverDailyLimitException(String errorMessage) {

--- a/src/main/java/com/google/maps/errors/OverQueryLimitException.java
+++ b/src/main/java/com/google/maps/errors/OverQueryLimitException.java
@@ -15,7 +15,7 @@
 
 package com.google.maps.errors;
 
-/** Indicates that the requesting account has exceeded short-term quota. */
+/** Indicates that the requesting account has exceeded its short-term quota. */
 public class OverQueryLimitException extends ApiException {
 
   private static final long serialVersionUID = -6888513535435397042L;

--- a/src/main/java/com/google/maps/model/LatLng.java
+++ b/src/main/java/com/google/maps/model/LatLng.java
@@ -28,7 +28,7 @@ public class LatLng implements UrlValue {
   public double lng;
 
   /**
-   * Construct a location with a latitude/longitude pair.
+   * Constructs a location with a latitude/longitude pair.
    *
    * @param lat The latitude of this location.
    * @param lng The longitude of this location.

--- a/src/main/java/com/google/maps/model/LocationType.java
+++ b/src/main/java/com/google/maps/model/LocationType.java
@@ -24,26 +24,25 @@ import com.google.maps.internal.StringJoin.UrlValue;
  */
 public enum LocationType implements UrlValue {
   /**
-   * {@code ROOFTOP} restricts the results to addresses for which we have location information
-   * accurate down to street address precision.
+   * Restricts the results to addresses for which we have location information accurate down to
+   * street address precision.
    */
   ROOFTOP,
 
   /**
-   * {@code RANGE_INTERPOLATED} restricts the results to those that reflect an approximation
-   * (usually on a road) interpolated between two precise points (such as intersections). An
-   * interpolated range generally indicates that rooftop geocodes are unavailable for a street
-   * address.
+   * Restricts the results to those that reflect an approximation (usually on a road) interpolated
+   * between two precise points (such as intersections). An interpolated range generally indicates
+   * that rooftop geocodes are unavailable for a street address.
    */
   RANGE_INTERPOLATED,
 
   /**
-   * {@code GEOMETRIC_CENTER} restricts the results to geometric centers of a location such as a
-   * polyline (for example, a street) or polygon (region).
+   * Restricts the results to geometric centers of a location such as a polyline (for example, a
+   * street) or polygon (region).
    */
   GEOMETRIC_CENTER,
 
-  /** {@code APPROXIMATE} restricts the results to those that are characterized as approximate. */
+  /** Restricts the results to those that are characterized as approximate. */
   APPROXIMATE,
 
   /**

--- a/src/main/java/com/google/maps/model/OpeningHours.java
+++ b/src/main/java/com/google/maps/model/OpeningHours.java
@@ -24,13 +24,13 @@ import org.joda.time.LocalTime;
  */
 public class OpeningHours {
   /**
-   * openNow is a boolean value indicating if the place is open at the current time.
+   * Whether the place is open at the current time.
    *
    * <p>Note: this field will be null if it isn't present in the response.
    */
   public Boolean openNow;
 
-  /** Period models the opening hours for a Place for a single day. */
+  /** The opening hours for a Place for a single day. */
   public static class Period {
     public static class OpenClose {
       public enum DayOfWeek {
@@ -63,20 +63,17 @@ public class OpeningHours {
     public Period.OpenClose close;
   }
 
-  /**
-   * periods is an array of opening periods covering seven days, starting from Sunday, in
-   * chronological order.
-   */
+  /** Opening periods covering seven days, starting from Sunday, in chronological order. */
   public Period[] periods;
 
   /**
-   * weekdayText is an array of seven strings representing the formatted opening hours for each day
-   * of the week; for example, "Monday: 8:30 am – 5:30 pm".
+   * The formatted opening hours for each day of the week, as an array of seven strings; for
+   * example, {@code "Monday: 8:30 am – 5:30 pm"}.
    */
   public String[] weekdayText;
 
   /**
-   * permanentlyClosed indicates that the place has permanently shut down.
+   * Indicates that the place has permanently shut down.
    *
    * <p>Note: this field will be null if it isn't present in the response.
    */


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

This PR covers classes with names starting with H-O.

Follows up #315.