### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes Q-S)

### DIFF
--- a/src/main/java/com/google/maps/QueryAutocompleteRequest.java
+++ b/src/main/java/com/google/maps/QueryAutocompleteRequest.java
@@ -47,8 +47,8 @@ public class QueryAutocompleteRequest
   }
 
   /**
-   * input is the text string on which to search. The Places service will return candidate matches
-   * based on this string and order results based on their perceived relevance.
+   * The text string on which to search. The Places service will return candidate matches based on
+   * this string and order results based on their perceived relevance.
    *
    * @param input The input text to autocomplete.
    * @return Returns this {@code QueryAutocompleteRequest} for call chaining.
@@ -58,10 +58,10 @@ public class QueryAutocompleteRequest
   }
 
   /**
-   * offset is the character position in the input term at which the service uses text for
-   * predictions. For example, if the input is 'Googl' and the completion point is 3, the service
-   * will match on 'Goo'. The offset should generally be set to the position of the text caret. If
-   * no offset is supplied, the service will use the entire term.
+   * The character position in the input term at which the service uses text for predictions. For
+   * example, if the input is 'Googl' and the completion point is 3, the service will match on
+   * 'Goo'. The offset should generally be set to the position of the text caret. If no offset is
+   * supplied, the service will use the entire term.
    *
    * @param offset The character offset to search from.
    * @return Returns this {@code QueryAutocompleteRequest} for call chaining.
@@ -71,7 +71,7 @@ public class QueryAutocompleteRequest
   }
 
   /**
-   * location is the point around which you wish to retrieve place information.
+   * The point around which you wish to retrieve place information.
    *
    * @param location The location point around which to search.
    * @return Returns this {@code QueryAutocompleteRequest} for call chaining.
@@ -81,9 +81,8 @@ public class QueryAutocompleteRequest
   }
 
   /**
-   * radius is the distance (in meters) within which to return place results. Note that setting a
-   * radius biases results to the indicated area, but may not fully restrict results to the
-   * specified area.
+   * The distance (in meters) within which to return place results. Note that setting a radius
+   * biases results to the indicated area, but may not fully restrict results to the specified area.
    *
    * @param radius The radius around which to bias results.
    * @return Returns this {@code QueryAutocompleteRequest} for call chaining.

--- a/src/main/java/com/google/maps/RadarSearchRequest.java
+++ b/src/main/java/com/google/maps/RadarSearchRequest.java
@@ -38,7 +38,7 @@ public class RadarSearchRequest
   }
 
   /**
-   * location is the latitude/longitude around which to retrieve place information.
+   * The latitude/longitude around which to retrieve place information.
    *
    * @param location The location around which to search.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -48,9 +48,8 @@ public class RadarSearchRequest
   }
 
   /**
-   * radius defines the distance (in meters) within which to return place results. The maximum
-   * allowed radius is 50,000 meters. Note that radius must not be included if rankby=DISTANCE is
-   * specified.
+   * The distance (in meters) within which to return place results. The maximum allowed radius is
+   * 50,000 meters. Note that radius must not be included if rankby=DISTANCE is specified.
    *
    * @param distance The radius distance to restrict results.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -63,9 +62,9 @@ public class RadarSearchRequest
   }
 
   /**
-   * keyword is a term to be matched against all content that Google has indexed for this place,
-   * including but not limited to name, type, and address, as well as customer reviews and other
-   * third-party content.
+   * A term to be matched against all content that Google has indexed for this place, including but
+   * not limited to name, type, and address, as well as customer reviews and other third-party
+   * content.
    *
    * @param keyword The keyword to search for.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -75,7 +74,7 @@ public class RadarSearchRequest
   }
 
   /**
-   * minPrice restricts to places that are at least this price level.
+   * Restricts to places that are at least this price level.
    *
    * @param priceLevel The minimum price level to restrict results with.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -85,7 +84,7 @@ public class RadarSearchRequest
   }
 
   /**
-   * maxPrice restricts to places that are at most this price level.
+   * Restricts to places that are at most this price level.
    *
    * @param priceLevel The maximum price level to restrict results with.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -95,8 +94,7 @@ public class RadarSearchRequest
   }
 
   /**
-   * name is one or more terms to be matched against the names of places, separated with a space
-   * character.
+   * One or more terms to be matched against the names of places, separated with space characters.
    *
    * @param name The name to restrict results with.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -106,7 +104,8 @@ public class RadarSearchRequest
   }
 
   /**
-   * openNow returns only those places that are open for business at the time the query is sent.
+   * Restricts the results to only those places that are open for business at the time the query is
+   * sent.
    *
    * @param openNow Whether to restrict to results that are open now.
    * @return Returns this {@code RadarSearchRequest} for call chaining.
@@ -116,7 +115,7 @@ public class RadarSearchRequest
   }
 
   /**
-   * type restricts the results to places matching the specified type.
+   * Restricts the results to places matching the specified type.
    *
    * @param type The Place Type to restrict results to.
    * @return Returns this {@code RadarSearchRequest} for call chaining.

--- a/src/main/java/com/google/maps/model/RankBy.java
+++ b/src/main/java/com/google/maps/model/RankBy.java
@@ -17,7 +17,7 @@ package com.google.maps.model;
 
 import com.google.maps.internal.StringJoin;
 
-/** RankBy is used by the Places API to specify the order in which results are listed. */
+/** Used by the Places API to specify the order in which results are listed. */
 public enum RankBy implements StringJoin.UrlValue {
   PROMINENCE("prominence"),
   DISTANCE("distance");

--- a/src/main/java/com/google/maps/model/SnappedPoint.java
+++ b/src/main/java/com/google/maps/model/SnappedPoint.java
@@ -17,16 +17,15 @@ package com.google.maps.model;
 
 /** A point that has been snapped to a road by the Roads API. */
 public class SnappedPoint {
-  /** {@code location} contains a latitude/longitude value representing the snapped location. */
+  /** A latitude/longitude value representing the snapped location. */
   public LatLng location;
 
   /**
-   * {@code originalIndex} is an integer that indicates the corresponding value in the original
-   * request. Each value in the request should map to a snapped value in the response. However, if
-   * you've set interpolate=true, then it's possible that the response will contain more coordinates
-   * than the request. Interpolated values will not have an originalIndex. These values are indexed
-   * from 0, so a point with an originalIndex of 4 will be the snapped value of the 5th lat/lng
-   * passed to the path parameter.
+   * The index of the corresponding value in the original request. Each value in the request should
+   * map to a snapped value in the response. However, if you've set interpolate=true, then it's
+   * possible that the response will contain more coordinates than the request. Interpolated values
+   * will not have an originalIndex. These values are indexed from 0, so a point with an
+   * originalIndex of 4 will be the snapped value of the 5th lat/lng passed to the path parameter.
    *
    * <p>A point that was not on the original path, or when interpolate=false, will have an
    * originalIndex of -1.
@@ -34,9 +33,9 @@ public class SnappedPoint {
   public int originalIndex = -1;
 
   /**
-   * {@code placeId} is a unique identifier for a place. All placeIds returned by the Roads API will
-   * correspond to road segments. The placeId can be passed to the speedLimit method to determine
-   * the speed limit along that road segment.
+   * A unique identifier for a place. All placeIds returned by the Roads API will correspond to road
+   * segments. The placeId can be passed to the speedLimit method to determine the speed limit along
+   * that road segment.
    */
   public String placeId;
 }

--- a/src/main/java/com/google/maps/model/SpeedLimit.java
+++ b/src/main/java/com/google/maps/model/SpeedLimit.java
@@ -18,13 +18,13 @@ package com.google.maps.model;
 /** A speed limit result from the Roads API. */
 public class SpeedLimit {
   /**
-   * {@code placeId} is a unique identifier for a place. All placeIds returned by the Roads API will
-   * correspond to road segments.
+   * A unique identifier for a place. All placeIds returned by the Roads API will correspond to road
+   * segments.
    */
   public String placeId;
 
   /**
-   * {@code speedLimit} is the speed limit for that road segment, specified in kilometers per hour.
+   * The speed limit for that road segment, specified in kilometers per hour.
    *
    * <p>To obtain the speed in miles per hour, use {@link #speedLimitMph()}.
    */

--- a/src/main/java/com/google/maps/model/StopDetails.java
+++ b/src/main/java/com/google/maps/model/StopDetails.java
@@ -24,9 +24,9 @@ package com.google.maps.model;
  */
 public class StopDetails {
 
-  /** The name of the transit station/stop. E.g. "Union Square". */
+  /** The name of the transit station/stop. E.g. {@code "Union Square"}. */
   public String name;
 
-  /** The location of the transit station/stop, represented as a latitude/longitude value. */
+  /** The location of the transit station/stop. */
   public LatLng location;
 }


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

Also includes minor wording and formatting changes.

This PR covers classes with names starting with Q-S.

Follows up #315.