### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes T)

### DIFF
--- a/src/main/java/com/google/maps/TextSearchRequest.java
+++ b/src/main/java/com/google/maps/TextSearchRequest.java
@@ -42,7 +42,7 @@ public class TextSearchRequest
   }
 
   /**
-   * query is the text string on which to search, for example: "restaurant".
+   * Specifies the text string on which to search, for example: {@code "restaurant"}.
    *
    * @param query The query string to search for.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -52,7 +52,7 @@ public class TextSearchRequest
   }
 
   /**
-   * location is the latitude/longitude around which to retrieve place information.
+   * Specifies the latitude/longitude around which to retrieve place information.
    *
    * @param location The location of the center of the search.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -62,7 +62,7 @@ public class TextSearchRequest
   }
 
   /**
-   * radius defines the distance (in meters) within which to bias place results.
+   * Specifies the distance (in meters) within which to bias place results.
    *
    * @param radius The radius of the search bias.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -75,7 +75,7 @@ public class TextSearchRequest
   }
 
   /**
-   * minPrice restricts to places that are at least this price level.
+   * Restricts to places that are at least this price level.
    *
    * @param priceLevel The minimum price level to restrict results with.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -85,7 +85,7 @@ public class TextSearchRequest
   }
 
   /**
-   * maxPrice restricts to places that are at most this price level.
+   * Restricts to places that are at most this price level.
    *
    * @param priceLevel The maximum price leve to restrict results with.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -95,8 +95,8 @@ public class TextSearchRequest
   }
 
   /**
-   * name is one or more terms to be matched against the names of places, separated with a space
-   * character.
+   * Specifies one or more terms to be matched against the names of places, separated with space
+   * characters.
    *
    * @param name The name to search for.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -106,7 +106,7 @@ public class TextSearchRequest
   }
 
   /**
-   * openNow returns only those places that are open for business at the time the query is sent.
+   * Restricts to only those places that are open for business at the time the query is sent.
    *
    * @param openNow Whether to restrict this search to open places.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -116,9 +116,9 @@ public class TextSearchRequest
   }
 
   /**
-   * pageToken returns the next 20 results from a previously run search. Setting pageToken will
-   * execute a search with the same parameters used previously — all parameters other than pageToken
-   * will be ignored.
+   * Returns the next 20 results from a previously run search. Setting pageToken will execute a
+   * search with the same parameters used previously — all parameters other than pageToken will be
+   * ignored.
    *
    * @param nextPageToken A {@code pageToken} from a prior result.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -128,7 +128,7 @@ public class TextSearchRequest
   }
 
   /**
-   * rankby specifies the order in which results are listed.
+   * Specifies the order in which results are listed.
    *
    * @param ranking The rank by method.
    * @return Returns this {@code TextSearchRequest} for call chaining.
@@ -138,7 +138,7 @@ public class TextSearchRequest
   }
 
   /**
-   * type restricts the results to places matching the specified type.
+   * Restricts the results to places matching the specified type.
    *
    * @param type The type of place to restrict the results with.
    * @return Returns this {@code TextSearchRequest} for call chaining.

--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -36,7 +36,7 @@ public class TimeZoneApi {
   private TimeZoneApi() {}
 
   /**
-   * Retrieve the {@link java.util.TimeZone} for the given location.
+   * Retrieves the {@link java.util.TimeZone} for the given location.
    *
    * @param context The {@link GeoApiContext} to make requests through.
    * @param location The location for which to retrieve a time zone.

--- a/src/main/java/com/google/maps/model/TransitAgency.java
+++ b/src/main/java/com/google/maps/model/TransitAgency.java
@@ -24,12 +24,12 @@ package com.google.maps.model;
  */
 public class TransitAgency {
 
-  /** {@code name} contains the name of the transit agency. */
+  /** The name of the transit agency. */
   public String name;
 
-  /** {@code url} contains the URL for the transit agency. */
+  /** The URL for the transit agency. */
   public String url;
 
-  /** {@code phone} contains the phone number of the transit agency. */
+  /** The phone number of the transit agency. */
   public String phone;
 }

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -26,44 +26,37 @@ import org.joda.time.DateTime;
  */
 public class TransitDetails {
 
-  /**
-   * {@code arrivalStop} contains information about the arrival stop/station for this part of the
-   * trip.
-   */
+  /** Information about the arrival stop/station for this part of the trip. */
   public StopDetails arrivalStop;
 
-  /**
-   * {@code departureStop} contains information about the departure stop/station for this part of
-   * the trip.
-   */
+  /** Information about the departure stop/station for this part of the trip. */
   public StopDetails departureStop;
 
-  /** {@code arrivalTime} contains the arrival time for this leg of the journey. */
+  /** The arrival time for this leg of the journey. */
   public DateTime arrivalTime;
 
-  /** {@code departureTime} contains the departure time for this leg of the journey. */
+  /** The departure time for this leg of the journey. */
   public DateTime departureTime;
 
   /**
-   * {@code headsign} specifies the direction in which to travel on this line, as it is marked on
-   * the vehicle or at the departure stop. This will often be the terminus station.
+   * The direction in which to travel on this line, as it is marked on the vehicle or at the
+   * departure stop. This will often be the terminus station.
    */
   public String headsign;
 
   /**
-   * {@code headway} specifies the expected number of seconds between departures from the same stop
-   * at this time. For example, with a headway value of 600, you would expect a ten minute wait if
-   * you should miss your bus.
+   * The expected number of seconds between departures from the same stop at this time. For example,
+   * with a headway value of 600, you would expect a ten minute wait if you should miss your bus.
    */
   public long headway;
 
   /**
-   * {@code numStops} contains the number of stops in this step, counting the arrival stop, but not
-   * the departure stop. For example, if your directions involve leaving from Stop A, passing
-   * through stops B and C, and arriving at stop D, {@code numStops} will equal 3.
+   * The number of stops in this step, counting the arrival stop, but not the departure stop. For
+   * example, if your directions involve leaving from Stop A, passing through stops B and C, and
+   * arriving at stop D, {@code numStops} will equal 3.
    */
   public int numStops;
 
-  /** {@code line} contains information about the transit line used in this step. */
+  /** Information about the transit line used in this step. */
   public TransitLine line;
 }

--- a/src/main/java/com/google/maps/model/TransitLine.java
+++ b/src/main/java/com/google/maps/model/TransitLine.java
@@ -24,39 +24,36 @@ package com.google.maps.model;
  */
 public class TransitLine {
 
-  /** {@code name} contains the full name of this transit line. E.g. "7 Avenue Express". */
+  /** The full name of this transit line. E.g. {@code "7 Avenue Express"}. */
   public String name;
 
   /**
-   * {@code shortName} contains the short name of this transit line. This will normally be a line
-   * number, such as "M7" or "355".
+   * The short name of this transit line. This will normally be a line number, such as {@code "M7"}
+   * or {@code "355"}.
    */
   public String shortName;
 
   /**
-   * {@code color} contains the color commonly used in signage for this transit line. The color will
-   * be specified as a hex string such as: #FF0033.
+   * The color commonly used in signage for this transit line. The color will be specified as a hex
+   * string, such as {@code "#FF0033"}.
    */
   public String color;
 
-  /**
-   * {@code agencies} contains an array of TransitAgency objects that each provide information about
-   * the operator of the line.
-   */
+  /** Information about the operator(s) of this transit line. */
   public TransitAgency[] agencies;
 
-  /** {@code url} contains the URL for this transit line as provided by the transit agency. */
+  /** The URL for this transit line as provided by the transit agency. */
   public String url;
 
-  /** {@code icon} contains the URL for the icon associated with this line. */
+  /** The URL for the icon associated with this transit line. */
   public String icon;
 
   /**
-   * {@code textColor} contains the color of text commonly used for signage of this line. The color
-   * will be specified as a hex string.
+   * The color of text commonly used for signage of this transit line. The color will be specified
+   * as a hex string, such as {@code "#FF0033"}.
    */
   public String textColor;
 
-  /** {@code vehicle} contains the type of vehicle used on this line. */
+  /** The type of vehicle used on this transit line. */
   public Vehicle vehicle;
 }

--- a/src/main/java/com/google/maps/model/TransitRoutingPreference.java
+++ b/src/main/java/com/google/maps/model/TransitRoutingPreference.java
@@ -3,7 +3,7 @@ package com.google.maps.model;
 import com.google.maps.internal.StringJoin.UrlValue;
 import java.util.Locale;
 
-/** Indicate user preference when requesting transit directions. */
+/** Indicates user preference when requesting transit directions. */
 public enum TransitRoutingPreference implements UrlValue {
   LESS_WALKING,
   FEWER_TRANSFERS;


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

Also includes minor wording changes, for consistency within classes.

This PR covers classes with names starting with T.

Follows up #315.