### PR TITLE
Javadoc: Rephrase to match Google Java Style Guide (classes U-Z)

### DIFF
--- a/src/main/java/com/google/maps/model/Vehicle.java
+++ b/src/main/java/com/google/maps/model/Vehicle.java
@@ -24,19 +24,18 @@ package com.google.maps.model;
  */
 public class Vehicle {
 
-  /** {@code name} contains the name of the vehicle on this line. E.g. "Subway." */
+  /** The name of the vehicle on this line. E.g. {@code "Subway"}. */
   public String name;
 
   /**
-   * {@code type} contains the type of vehicle that runs on this line. See the {@link
-   * com.google.maps.model.VehicleType VehicleType} documentation for a complete list of supported
-   * values.
+   * The type of vehicle that runs on this line. See the {@link com.google.maps.model.VehicleType
+   * VehicleType} documentation for a complete list of supported values.
    */
   public VehicleType type;
 
-  /** {@code icon} contains the URL for an icon associated with this vehicle type. */
+  /** The URL for an icon associated with this vehicle type. */
   public String icon;
 
-  /** {@code localIcon} contains the URL for an icon based on the local transport signage. */
+  /** The URL for an icon based on the local transport signage. */
   public String localIcon;
 }

--- a/src/main/java/com/google/maps/model/WifiAccessPoint.java
+++ b/src/main/java/com/google/maps/model/WifiAccessPoint.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 /**
- * WiFi access point objects.
+ * A WiFi access point.
  *
  * <p>The request body's {@code wifiAccessPoints} array must contain two or more WiFi access point
  * objects. {@code macAddress} is required; all other fields are optional.
@@ -42,18 +42,18 @@ public class WifiAccessPoint {
     signalToNoiseRatio = _signalToNoiseRatio;
   }
   /**
-   * {@code macAddress}: (required) The MAC address of the WiFi node. Separators must be : (colon)
-   * and hex digits must use uppercase.
+   * The MAC address of the WiFi node (required). Separators must be {@code :} (colon) and hex
+   * digits must use uppercase.
    */
   // TODO: add validation and test cases for malformed MAC Asdresses
   public String macAddress;
-  /** {@code signalStrength}: The current signal strength measured in dBm. */
+  /** The current signal strength measured in dBm. */
   public Integer signalStrength = null;
-  /** {@code age}: The number of milliseconds since this access point was detected. */
+  /** The number of milliseconds since this access point was detected. */
   public Integer age = null;
-  /** {@code channel}: The channel over which the client is communicating with the access point. */
+  /** The channel over which the client is communicating with the access point. */
   public Integer channel = null;
-  /** {@code signalToNoiseRatio}: The current signal to noise ratio measured in dB. */
+  /** The current signal to noise ratio measured in dB. */
   public Integer signalToNoiseRatio = null;
 
   public static class WifiAccessPointBuilder {


### PR DESCRIPTION
This rephrases several Javadoc elements to conform to [section 7 ("Javadoc")](https://google.github.io/styleguide/javaguide.html#s7-javadoc) of the Google Java Style Guide.

Also includes minor additions of "code" markup.

This PR covers classes with names starting with U-Z.

Follows up #315.