### PR TITLE
Javadoc: Use "latitude/longitude" instead of "latitude,longitude" everywhere

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -190,7 +190,7 @@ public class DirectionsApiRequest
   }
 
   /**
-   * The list of waypoints as latitude,longitude locations.
+   * The list of waypoints as latitude/longitude locations.
    *
    * @param waypoints The waypoints to add to this directions request.
    * @return Returns this {@code DirectionsApiRequest} for call chaining.

--- a/src/main/java/com/google/maps/model/Geometry.java
+++ b/src/main/java/com/google/maps/model/Geometry.java
@@ -26,8 +26,8 @@ public class Geometry {
   public Bounds bounds;
 
   /**
-   * {@code location} contains the geocoded {@code latitude,longitude} value. For normal address
-   * lookups, this field is typically the most important.
+   * {@code location} contains the geocoded latitude/longitude value. For normal address lookups,
+   * this field is typically the most important.
    */
   public LatLng location;
 


### PR DESCRIPTION
In this project, when talking about latitude/longitude coordinates, the styling "latitude/longitude" is predominant over "latitude,longitude". (And IMHO, "latitude/longitude" is more conventional English prose.)

```
$ grep -r latitude/longitude * | wc -l
      22
$ grep -r latitude,longitude * | wc -l
       2
```

This PR changes the remaining "latitude,longitude" instances to be "latitude/longitude".

It also removes the `{@code ...}` markup from one of the instances, because it's not referring to a literal code value or identifiers there.