### PR TITLE
guava v22 and v23 reintroduced java 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,8 @@ dependencies {
     compile 'joda-time:joda-time:2.9.9'
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.54'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'com.google.guava:guava:20.0' // Note, v20 is the last JDK7 supporting release of Guava
+    compile 'com.google.guava:guava:23.0-android' // Note, v23.0-android is the last JDK7 supporting release of Guava
+                                                  // but still don't use google-maps-services-java on android
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
https://github.com/google/guava/wiki/Release22
https://github.com/google/guava/wiki/Release23
the guava version is tagged with -android but as has been said many times please don't use google-maps-services-java with android.