### PR TITLE
.gitignore: add /out/ to support IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/out/
 /bin/
 /com/
 .gradle/


### PR DESCRIPTION
I tried out IntelliJ IDEA with this project and found another variant of gradle-driven build directories which should be ignored by git. Mind adding this in?

This is the build directory used by IntelliJ IDEA with this project, and should
be ignored like /build/ and .nb-gradle/.