### PR TITLE
added a shutdown method to GeoApiContext which stops RateLimitExecutorDelayThread #261

### DIFF
--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -93,6 +93,11 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
         req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
+  @Override
+  public void shutdown() {
+    //do nothing
+  }
+
   /** Builder strategy for constructing {@code GaeRequestHandler}. */
   public static class Builder implements GeoApiContext.RequestHandler.Builder {
 

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -104,6 +104,8 @@ public class GeoApiContext {
         Integer maxRetries,
         ExceptionsAllowedToRetry exceptionsAllowedToRetry);
 
+    void shutdown();
+
     /** Builder pattern for {@code GeoApiContext.RequestHandler}. */
     interface Builder {
 
@@ -121,6 +123,10 @@ public class GeoApiContext {
 
       RequestHandler build();
     }
+  }
+
+  public void shutdown() {
+    requestHandler.shutdown();
   }
 
   <T, R extends ApiResponse<T>> PendingResult<T> get(

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -23,6 +23,7 @@ import com.google.maps.internal.OkHttpPendingResult;
 import com.google.maps.internal.RateLimitExecutorService;
 import java.io.IOException;
 import java.net.Proxy;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
@@ -42,9 +43,11 @@ import okhttp3.Route;
 public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
   private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   private final OkHttpClient client;
+  private final ExecutorService executorService;
 
-  /* package */ OkHttpRequestHandler(OkHttpClient client) {
+  /* package */ OkHttpRequestHandler(OkHttpClient client, ExecutorService executorService) {
     this.client = client;
+    this.executorService = executorService;
   }
 
   @Override
@@ -85,6 +88,10 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
     return new OkHttpPendingResult<T, R>(
         req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+  }
+
+  public void shutdown() {
+    executorService.shutdown();
   }
 
   /** Builder strategy for constructing an {@code OkHTTPRequestHandler}. */
@@ -149,7 +156,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
     @Override
     public RequestHandler build() {
       OkHttpClient client = builder.build();
-      return new OkHttpRequestHandler(client);
+      return new OkHttpRequestHandler(client, rateLimitExecutorService);
     }
   }
 }

--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -15,7 +15,10 @@
 
 package com.google.maps;
 
+import static com.google.maps.TestUtils.findLastThreadByName;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -290,5 +293,21 @@ public class GeoApiContextTest {
     }
 
     fail("OverQueryLimitException was expected but not observed.");
+  }
+
+  @Test
+  public void testShutdown() throws InterruptedException {
+    GeoApiContext context = builder.build();
+    final Thread delayThread = findLastThreadByName("RateLimitExecutorDelayThread");
+    assertNotNull(
+        "Delay thread should be created in constructor of RateLimitExecutorService", delayThread);
+    assertTrue(
+        "Delay thread should start in constructor of RateLimitExecutorService",
+        delayThread.isAlive());
+    //this is needed to make sure that delay thread has reached queue.take()
+    delayThread.join(10);
+    context.shutdown();
+    delayThread.join(10);
+    assertFalse(delayThread.isAlive());
   }
 }

--- a/src/test/java/com/google/maps/TestUtils.java
+++ b/src/test/java/com/google/maps/TestUtils.java
@@ -32,4 +32,18 @@ public class TestUtils {
       return body;
     }
   }
+
+  public static Thread findLastThreadByName(String name) {
+    ThreadGroup currentThreadGroup = Thread.currentThread().getThreadGroup();
+    Thread[] threads = new Thread[1000];
+    currentThreadGroup.enumerate(threads);
+    Thread delayThread = null;
+    for (Thread thread : threads) {
+      if (thread == null) break;
+      if (thread.getName().equals(name)) {
+        delayThread = thread;
+      }
+    }
+    return delayThread;
+  }
 }

--- a/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
+++ b/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
@@ -15,6 +15,8 @@
 
 package com.google.maps.internal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.maps.MediumTests;
@@ -89,5 +91,21 @@ public class RateLimitExecutorServiceTest {
       counter += value;
     }
     return counter;
+  }
+
+  @Test
+  public void testDelayThreadIsStoppedAfterShutdownIsCalled() throws InterruptedException {
+    RateLimitExecutorService service = new RateLimitExecutorService();
+    final Thread delayThread = service.delayThread;
+    assertNotNull(
+        "Delay thread should be created in constructor of RateLimitExecutorService", delayThread);
+    assertTrue(
+        "Delay thread should start in constructor of RateLimitExecutorService",
+        delayThread.isAlive());
+    //this is needed to make sure that delay thread has reached queue.take()
+    delayThread.join(10);
+    service.shutdown();
+    delayThread.join(10);
+    assertFalse(delayThread.isAlive());
   }
 }


### PR DESCRIPTION
This is a pull request for issue #261. Details can be found in the [comment](https://github.com/googlemaps/google-maps-services-java/issues/261#issuecomment-341965630) but I will also copy them here for convenience.

The root cause of the issue is following. We are creating and starting a thread in a constructor of class [RateLimitExecutorService](https://github.com/googlemaps/google-maps-services-java/blob/7d7f0b998a734acc7f32ffb4760e84c1d288e4bb/src/main/java/com/google/maps/internal/RateLimitExecutorService.java#L36). Here it is:
```java
public RateLimitExecutorService() {
    setQueriesPerSecond(DEFAULT_QUERIES_PER_SECOND);
    Thread delayThread = new Thread(this);
    delayThread.setDaemon(true);
    delayThread.setName("RateLimitExecutorDelayThread");
    delayThread.start();
}
```
[run](https://github.com/googlemaps/google-maps-services-java/blob/7d7f0b998a734acc7f32ffb4760e84c1d288e4bb/src/main/java/com/google/maps/internal/RateLimitExecutorService.java#L72) method of this class looks like this:
```java
@Override
public void run() {
  try {
    while (!delegate.isShutdown()) {
      this.rateLimiter.acquire();
      Runnable r = queue.take();
      delegate.execute(r);
    }
  } catch (InterruptedException ie) {
    LOG.info("Interrupted", ie);
  }
}
```
There are two problems with this method:
1. `RateLimitExecutorDelayThread` should end when the delegate is shut down but the thing is [RateLimitExecutorService#shutdown](https://github.com/googlemaps/google-maps-services-java/blob/7d7f0b998a734acc7f32ffb4760e84c1d288e4bb/src/main/java/com/google/maps/internal/RateLimitExecutorService.java#L103) method and thus `shutdown()` method of the delegate is never called.
2. If we call `shutdown()` method but the `queue` is empty we will wait forever in `queue.take()`.

This issue manifests itself when you are restarting an application multiple times inside a single JVM without restarting JVM itself. For example, it can happen in application servers like Tomcat or in Play Framework's dev mode, which was my case.