### PR TITLE
ResponseBody in OkHttpPendingResult was not being closed.

### DIFF
--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -220,7 +220,10 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
       return request.retry();
     }
 
-    byte[] bytes = response.body().bytes();
+    byte[] bytes;
+    try (ResponseBody body = response.body()) {
+        bytes = body.bytes();
+    }
     R resp;
     String contentType = response.header("Content-Type");
 


### PR DESCRIPTION
Was getting the following warning without this change:

Nov 08, 2017 2:55:28 PM okhttp3.internal.platform.Platform log
WARNING: A connection to https://maps.googleapis.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);