### PR TITLE
Fix build: ResponseBody not imported in OkHttpPendingResult

### DIFF
--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -45,6 +45,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.joda.time.LocalTime;

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -222,7 +222,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
 
     byte[] bytes;
     try (ResponseBody body = response.body()) {
-        bytes = body.bytes();
+      bytes = body.bytes();
     }
     R resp;
     String contentType = response.header("Content-Type");


### PR DESCRIPTION
Looks like #368 broke the build: in the current version, `ResponseBody` is used but not imported.

When I build from `master` at commit 33dea390375d9218de9d2afb913f5db817699185, I get this build error:

```
$ ./gradlew build

> Task :compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
/Users/janke/local/repos/google-maps-services-java/build/filtered/src/main/java/com/google/maps/internal/OkHttpPendingResult.java:224: error: cannot find symbol
    try (ResponseBody body = response.body()) {
         ^
  symbol:   class ResponseBody
  location: class OkHttpPendingResult<T,R>
  where T,R are type-variables:
    T extends Object declared in class OkHttpPendingResult
    R extends ApiResponse<T> declared in class OkHttpPendingResult
1 error


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
2 actionable tasks: 2 executed
```

This PR fixes it by adding the import.

This PR also includes a style fix so the build passes the googleJavaFormat style check.