### PR TITLE
Suppress unchecked warning in GeoApiContextTest

### DIFF
--- a/src/test/java/com/google/maps/GeoApiContextTest.java
+++ b/src/test/java/com/google/maps/GeoApiContextTest.java
@@ -65,6 +65,7 @@ public class GeoApiContextTest {
     builder.baseUrlForTesting("http://127.0.0.1:" + server.getPort());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetIncludesDefaultUserAgent() throws Exception {
     // Set up a mock request


### PR DESCRIPTION
What do you think about suppressing this unchecked-conversion warning in the GeoApiContextTest? Since it's just in a test using mock objects, I think that'd be acceptable.

When compiling now, I get this "note" output from the test compilation step.

```
> Task :compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
Note: /Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/GeoApiContextTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

With `-Xlint:unchecked` on:

```
> Task :compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
/Users/janke/local/repos/google-maps-services-java/src/test/java/com/google/maps/GeoApiContextTest.java:82: warning: [unchecked] unchecked method invocation: method get in class GeoApiContext is applied to given types
    builder.build().get(new ApiConfig(path), fakeResponse.getClass(), params).awaitIgnoreError();
                       ^
  required: ApiConfig,Class<? extends R>,Map<String,String>
  found: ApiConfig,Class<CAP#1>,Map<String,String>
  where R,T are type-variables:
    R extends ApiResponse<T> declared in method <T,R>get(ApiConfig,Class<? extends R>,Map<String,String>)
    T extends Object declared in method <T,R>get(ApiConfig,Class<? extends R>,Map<String,String>)
  where CAP#1 is a fresh type-variable:
    CAP#1 extends ApiResponse from capture of ? extends ApiResponse
2 warnings
```

I've taken a stab at it, and I can't figure out how to wrangle the types to get it to compile without the warning, while using the dynamic `getClass()` off the mocked `ApiResponse` object.

This codebase is pretty close to a warning-clean build; this gets one step closer.