### PR TITLE
Sync up .gitignore with master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
+/build/
+/out/
+/bin/
+/com/
 .gradle/
+.nb-gradle/
+.nb-gradle-properties
+*.iml
 .idea/
-build/
-google-maps-services-java.iml
+.settings/
+.project
+.classpath
+.vscode/


### PR DESCRIPTION
This PR pulls in all the new items in `.gitignore` on `master`, so IDE droppings and the like are still ignored when switching between the branches.