### PR TITLE
AddressType: add more types observed by steveetl

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -242,6 +242,42 @@ public enum AddressType implements UrlValue {
   /** Currently not a documented return type. */
   SPA("spa"),
 
+  /** Currently not a documented return type. */
+  BAKERY("bakery"),
+
+  /** Currently not a documented return type. */
+  PHARMACY("pharmacy"),
+
+  /** Currently not a documented return type. */
+  SCHOOL("school"),
+
+  /** Currently not a documented return type. */
+  BOOK_STORE("book_store"),
+
+  /** Currently not a documented return type. */
+  DEPARTMENT_STORE("department_store"),
+
+  /** Currently not a documented return type. */
+  RESTAURANT("restaurant"),
+
+  /** Currently not a documented return type. */
+  REAL_ESTATE_AGENCY("real_estate_agency"),
+
+  /** Currently not a documented return type. */
+  BAR("bar"),
+
+  /** Currently not a documented return type. */
+  DOCTOR("doctor"),
+
+  /** Currently not a documented return type. */
+  HOSPITAL("hospital"),
+
+  /** Currently not a documented return type. */
+  FIRE_STATION("fire_station"),
+
+  /** Currently not a documented return type. */
+  SUPERMARKET("supermarket"),
+
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps
    * Services should be updated to support the new value.


### PR DESCRIPTION
Fixes #226 (comment https://github.com/googlemaps/google-maps-services-java/issues/226#issuecomment-340790353)

This PR includes the `SUPERMARKET` type because even though it's not listed in the [official web page](https://developers.google.com/places/supported_types) as of this writing, @steveetl reports seeing it in the wild.