### PR TITLE
AddressType: add shoe_store

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -242,6 +242,9 @@ public enum AddressType implements UrlValue {
   /** Currently not a documented return type. */
   SPA("spa"),
 
+  /** Currently not a documented return type. */
+  SHOE_STORE("shoe_store"),
+
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps
    * Services should be updated to support the new value.


### PR DESCRIPTION
This PR adds the `shoe_store` `AddressType`.

Before: Produces warning:

```
$ ./bin/gmsj-cli geocode "bucket shoe store"
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'shoe_store'
Results length: 1
Result 0:
Formatted Address: 1924 8th St NW, Washington, DC 20001, USA
Types: establishment / point_of_interest / unknown / store
PlaceId: ChIJ8cLMP-W3t4kRHrH3_aZWIx0
```

After: No warning:

```
$ ./bin/gmsj-cli geocode "bucket shoe store"
Results length: 1
Result 0:
Formatted Address: 1924 8th St NW, Washington, DC 20001, USA
Types: establishment / point_of_interest / shoe_store / store
PlaceId: ChIJ8cLMP-W3t4kRHrH3_aZWIx0
```