### PR TITLE
AddressType: add travel_agency

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -233,6 +233,9 @@ public enum AddressType implements UrlValue {
   /** Currently not a documented return type. */
   STADIUM("stadium"),
 
+  /** Currently not a documented return type. */
+  TRAVEL_AGENCY("travel_agency"),  
+
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps
    * Services should be updated to support the new value.


### PR DESCRIPTION
This PR adds the `travel_agency` AddressType.

Before:

```
$ ./bin/gmsj-cli geocode "wherever"
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'travel_agency'
Results length: 1
Result 0:
Formatted Address: 440 S Main St, Milltown, NJ 08850, USA
[...]
```

After:

```
$ ./bin/gmsj-cli geocode "wherever"
Results length: 1
Result 0:
Formatted Address: 440 S Main St, Milltown, NJ 08850, USA
Types: establishment / point_of_interest / travel_agency
[...]
```