### PR TITLE
AddressType: add night_club

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -233,6 +233,9 @@ public enum AddressType implements UrlValue {
   /** Currently not a documented return type. */
   STADIUM("stadium"),
 
+  /** Currently not a documented return type. */
+  TRAVEL_AGENCY("travel_agency"),  
+
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps
    * Services should be updated to support the new value.

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -234,7 +234,10 @@ public enum AddressType implements UrlValue {
   STADIUM("stadium"),
 
   /** Currently not a documented return type. */
-  TRAVEL_AGENCY("travel_agency"),  
+  TRAVEL_AGENCY("travel_agency"),
+
+  /** Currently not a documented return type. */
+  NIGHT_CLUB("night_club"),
 
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps


### PR DESCRIPTION
This PR adds the `NIGHT_CLUB` `AddressType`.

Before:

```
$ ./bin/gmsj-cli geocode "BFE"
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'night_club'
Results length: 1
Result 0:
Formatted Address: 11528 Jones Rd, Houston, TX 77070, USA
Types: establishment / unknown / point_of_interest
```

After:
```
$ ./bin/gmsj-cli geocode "BFE"
Results length: 1
Result 0:
Formatted Address: 11528 Jones Rd, Houston, TX 77070, USA
Types: establishment / night_club / point_of_interest
```