### PR TITLE
Made the constructor public

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -30,7 +30,7 @@ import org.joda.time.ReadableInstant;
 public class DirectionsApiRequest
     extends PendingResultBase<DirectionsResult, DirectionsApiRequest, DirectionsApi.Response> {
 
-  DirectionsApiRequest(GeoApiContext context) {
+  public DirectionsApiRequest(GeoApiContext context) {
     super(context, DirectionsApi.API_CONFIG, DirectionsApi.Response.class);
   }
 


### PR DESCRIPTION
Rather than making the DirectionApiRequest.java as singleton class, we need to give its constructor the public access.