### PR TITLE
added museum to address type

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -124,6 +124,9 @@ public enum AddressType implements UrlValue {
 
   /** A named park. */
   PARK("park"),
+  
+  /** A museum. */
+  MUSEUM("museum"),
 
   /**
    * A named point of interest. Typically, these "POI"s are prominent local entities that don't


### PR DESCRIPTION
Added museum type after received this error:

```
WARN - com.google.maps.internal.SafeEnumAdapter : Unknown type for enum com.google.maps.model.AddressType: 'museum'
```
