### PR TITLE
Add support for scale parameter on custom icons to be able to use hi-DPI icons when map scale > 1

### DIFF
--- a/src/main/java/com/google/maps/StaticMapsRequest.java
+++ b/src/main/java/com/google/maps/StaticMapsRequest.java
@@ -16,10 +16,12 @@
 package com.google.maps;
 
 import com.google.maps.internal.ApiConfig;
+import com.google.maps.internal.StringJoin;
 import com.google.maps.internal.StringJoin.UrlValue;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.Size;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -311,7 +313,7 @@ public class StaticMapsRequest
 
       urlParts.addAll(locations);
 
-      return String.join("|", urlParts);
+      return StringJoin.join('|', urlParts.toArray(new String[urlParts.size()]));
     }
   }
 
@@ -416,7 +418,7 @@ public class StaticMapsRequest
 
       urlParts.addAll(points);
 
-      return String.join("|", urlParts);
+      return StringJoin.join('|', urlParts.toArray(new String[urlParts.size()]));
     }
   }
 

--- a/src/main/java/com/google/maps/StaticMapsRequest.java
+++ b/src/main/java/com/google/maps/StaticMapsRequest.java
@@ -200,6 +200,7 @@ public class StaticMapsRequest
     private String label;
     private String customIconURL;
     private CustomIconAnchor anchorPoint;
+    private Integer scale;
     private final List<String> locations = new ArrayList<>();
 
     /**
@@ -250,6 +251,19 @@ public class StaticMapsRequest
     }
 
     /**
+     * Set a custom icon for these markers.
+     *
+     * @param url URL for the custom icon.
+     * @param anchorPoint The anchor point for this custom icon.
+     * @param scale Set the image density scale (1, 2, or 4) of the custom icon provided.
+     */
+    public void customIcon(String url, CustomIconAnchor anchorPoint, int scale) {
+      this.customIconURL = url;
+      this.anchorPoint = anchorPoint;
+      this.scale = scale;
+    }
+
+    /**
      * Add the location of a marker. At least one is required.
      *
      * @param location The location of the added marker.
@@ -277,6 +291,10 @@ public class StaticMapsRequest
 
       if (anchorPoint != null) {
         urlParts.add("anchor:" + anchorPoint.toUrlValue());
+      }
+
+      if (scale != null) {
+        urlParts.add("scale:" + scale);
       }
 
       if (size != null && size != MarkersSize.normal) {

--- a/src/test/java/com/google/maps/StaticMapsApiTest.java
+++ b/src/test/java/com/google/maps/StaticMapsApiTest.java
@@ -134,7 +134,7 @@ public class StaticMapsApiTest {
       StaticMapsRequest req = StaticMapsApi.newRequest(sc.context, new Size(WIDTH, HEIGHT));
       Markers markers = new Markers();
       markers.size(MarkersSize.small);
-      markers.customIcon("http://not.a/real/url", CustomIconAnchor.bottomleft);
+      markers.customIcon("http://not.a/real/url", CustomIconAnchor.bottomleft, 2);
       markers.color("blue");
       markers.label("A");
       markers.addLocation("Melbourne");
@@ -153,7 +153,7 @@ public class StaticMapsApiTest {
       req.await();
 
       sc.assertParamValue(
-          "icon:http://not.a/real/url|anchor:bottomleft|size:small|color:blue|label:A|Melbourne|-33.86880000,151.20930000",
+          "icon:http://not.a/real/url|anchor:bottomleft|scale:2|size:small|color:blue|label:A|Melbourne|-33.86880000,151.20930000",
           "markers");
       sc.assertParamValue(
           "weight:3|color:green|fillcolor:0xAACCEE|geodesic:true|Melbourne|-33.86880000,151.20930000",


### PR DESCRIPTION
It appears that Google supports a `scale` parameter for custom marker icons although this is undocumented. See the Stack Overflow articles below. This is ultimately necessary when generating maps for hi-DPI screens where the overall map `scale` option is set to 2 or 4. I've tested with this locally and it appears to be working albeit it is undocumented by Google.

https://stackoverflow.com/questions/8813143/how-do-i-add-a-high-resolution-custom-marker-on-a-static-google-map

https://stackoverflow.com/questions/10336646/how-can-i-use-high-resolution-custom-markers-with-the-scale-parameter-in-google