### PR TITLE
New AddressComponentTypes: general_contractor, food, store, etc...

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -166,6 +166,27 @@ public enum AddressComponentType {
   /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
+  /** A general contractor. */
+  GENERAL_CONTRACTOR("general_contractor"),
+
+  /** A food service establishment. */
+  FOOD("food"),
+
+  /** A real-estate agency. */
+  REAL_ESTATE_AGENCY("real_estate_agency"),
+
+  /** A car-rental establishment. */
+  CAR_RENTAL("car_rental"),
+
+  /** A store. */
+  STORE("store"),
+
+  /** A shopping mall. */
+  SHOPPING_MALL("shopping_mall"),
+
+  /** A lodging establishment. */
+  LODGING("lodging"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.


### PR DESCRIPTION
... car_rental, real_estate_agency, shopping_mall, lodging

New types:

* general_contractor
* food
* store
* car_rental
* real_estate_agency
* shopping_mall
* lodging

I discovered these using a little [fuzz tester](https://github.com/apjanke/gmsj-cli/commit/4c1c892118fcd73c21d48ff4e203fff0b9042b4e) I wrote over at my [gmsj-cli project](https://github.com/apjanke/gmsj-cli).

```
$ ./bin/gmsj-cli geofuzz "World Trade Center" -n 5000 -S 123456
Searching 5000 points around 'World Trade Center', with radius 0.100000 degrees (rand seed 123456)
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'food'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'finance'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'car_rental'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'car_rental'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'store'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'shopping_mall'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'lodging'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'local_government_office'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'travel_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'lodging'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'food'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'clothing_store'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'store'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] INFO com.google.maps.internal.OkHttpPendingResult - Retrying request. Retry #1
[main] INFO com.google.maps.internal.OkHttpPendingResult - Retrying request. Retry #2
[main] INFO com.google.maps.internal.OkHttpPendingResult - Retrying request. Retry #3
Error: ApiException during geocoding: You have exceeded your daily request quota for this API.
```
