### PR TITLE
Add more AddressTypes and AddressComponentTypes

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -178,6 +178,18 @@ public enum AddressComponentType {
   /** A car-rental establishment. */
   CAR_RENTAL("car_rental"),
 
+  /** A travel agency. */
+  TRAVEL_AGENCY("travel_agency"),
+
+  /** An electronics store. */
+  ELECTRONICS_STORE("electronics_store"),
+
+  /** A home goods store. */
+  HOME_GOODS_STORE("home_goods_store"),
+
+  /** A school. */
+  SCHOOL("school"),
+
   /** A store. */
   STORE("store"),
 
@@ -186,6 +198,51 @@ public enum AddressComponentType {
 
   /** A lodging establishment. */
   LODGING("lodging"),
+
+  /** An art gallery. */
+  ART_GALLERY("art_gallery"),
+
+  /** A lawyer. */
+  LAWYER("lawyer"),
+
+  /** A restaurant. */
+  RESTAURANT("restaurant"),
+
+  /** A bar. */
+  BAR("bar"),
+
+  /** A take-away meal establishment. */
+  MEAL_TAKEAWAY("meal_takeaway"),
+
+  /** A clothing store. */
+  CLOTHING_STORE("clothing_store"),
+
+  /** A local government office. */
+  LOCAL_GOVERNMENT_OFFICE("local_government_office"),
+
+  /** A finance establishment. */
+  FINANCE("finance"),
+
+  /** A moving company. */
+  MOVING_COMPANY("moving_company"),
+
+  /** A storage establishment. */
+  STORAGE("storage"),
+
+  /** A cafe. */
+  CAFE("cafe"),
+
+  /** A car repair establishment. */
+  CAR_REPAIR("car_repair"),
+
+  /** A health service provider. */
+  HEALTH("health"),
+
+  /** An insurance agency. */
+  INSURANCE_AGENCY("insurance_agency"),
+
+  /** A painter. */
+  PAINTER("painter"),
 
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -381,6 +381,9 @@ public enum AddressType implements UrlValue {
   FUNERAL_HOME("funeral_home"),
 
   /** Currently not a documented return type. */
+  GENERAL_CONTRACTOR("general_contractor"),
+
+  /** Currently not a documented return type. */
   HINDU_TEMPLE("hindu_temple"),
 
   /** Currently not a documented return type. */

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -150,6 +150,36 @@ public class EnumsTest {
     addressComponentTypeToLiteralMap.put(AddressComponentType.POSTAL_TOWN, "postal_town");
     addressComponentTypeToLiteralMap.put(AddressComponentType.ROOM, "room");
     addressComponentTypeToLiteralMap.put(AddressComponentType.STREET_NUMBER, "street_number");
+    addressComponentTypeToLiteralMap.put(
+        AddressComponentType.GENERAL_CONTRACTOR, "general_contractor");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.FOOD, "food");
+    addressComponentTypeToLiteralMap.put(
+        AddressComponentType.REAL_ESTATE_AGENCY, "real_estate_agency");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.CAR_RENTAL, "car_rental");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.STORE, "store");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SHOPPING_MALL, "shopping_mall");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.LODGING, "lodging");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.TRAVEL_AGENCY, "travel_agency");
+    addressComponentTypeToLiteralMap.put(
+        AddressComponentType.ELECTRONICS_STORE, "electronics_store");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.HOME_GOODS_STORE, "home_goods_store");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.SCHOOL, "school");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.ART_GALLERY, "art_gallery");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.LAWYER, "lawyer");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.RESTAURANT, "restaurant");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.BAR, "bar");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.MEAL_TAKEAWAY, "meal_takeaway");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.CLOTHING_STORE, "clothing_store");
+    addressComponentTypeToLiteralMap.put(
+        AddressComponentType.LOCAL_GOVERNMENT_OFFICE, "local_government_office");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.FINANCE, "finance");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.MOVING_COMPANY, "moving_company");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.STORAGE, "storage");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.CAFE, "cafe");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.CAR_REPAIR, "car_repair");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.HEALTH, "health");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.INSURANCE_AGENCY, "insurance_agency");
+    addressComponentTypeToLiteralMap.put(AddressComponentType.PAINTER, "painter");
 
     for (Map.Entry<AddressComponentType, String> AddressComponentTypeLiteralPair :
         addressComponentTypeToLiteralMap.entrySet()) {


### PR DESCRIPTION
This PR adds more currently-unrecognized AddressComponentTypes and AddressTypes.

AddressTypes:
* general_contractor

AddressComponentTypes:
* travel_agency
* electronics_store
* home_goods_store
* school
* store
* art_gallery
* lawyer
* restaurant
* bar
* meal_takeaway
* clothing_store
* local_government_office
* finance
* moving_company
* storage

These were discovered using my [gmsj-cli](https://github.com/apjanke/gmsj-cli) fuzz tester.

```
$ ./bin/gmsj-cli geofuzz "555 Broadway, New York, NY" -n 5000 -S 123456                                                                                           master
Searching 5000 points around '555 Broadway, New York, NY', with radius 0.100000 degrees (rand seed 123456)
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'travel_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'travel_agency'
[...]
```