### PR TITLE
AddressComponentType: add CAFE

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -166,6 +166,9 @@ public enum AddressComponentType {
   /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
+  /** A cafe. */
+  CAFE("cafe"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.


### PR DESCRIPTION
Add a CAFE type.

Discovered through [gmsj-cli fuzzing](https://github.com/apjanke/gmsj-cli/commit/b0f7403cff1423764dc961e49a974c40f99e7c9b).

```
$ ./bin/gmsj-cli geofuzz "Shibuya, Tokyo, Japan" -n 500 -S 123456
Searching 500 points around 'Shibuya, Tokyo, Japan', with radius 0.100000 degrees (rand seed 123456)
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'cafe'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'food'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'restaurant'
```

Somewhat surprising that there is a cafe in Shibuya, but none in downtown New York when I fuzzed around there.