### PR TITLE
AddressComponentType: add health

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -166,6 +166,9 @@ public enum AddressComponentType {
   /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
+  /** A health service provider. */
+  HEALTH("health"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.


### PR DESCRIPTION
This PR adds the `health` type to AddressComponentTypes.

Found while [fuzzing](https://github.com/apjanke/gmsj-cli/commit/b0f7403cff1423764dc961e49a974c40f99e7c9b) around the Fluevog shoe store in Chicago.

```
$ ./bin/gmsj-cli geofuzz "1539 N Milwaukee Ave, Chicago, IL, USA" -n 500 -S 123456
Searching 500 points around '1539 N Milwaukee Ave, Chicago, IL, USA', with radius 0.100000 degrees (rand seed 123456)
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'health'
[...]
```