### PR TITLE
Add AddressComponentType insurance_agency

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -166,6 +166,9 @@ public enum AddressComponentType {
   /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
+  /** An insurance agency. */
+  INSURANCE_AGENCY("insurance_agency"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.


### PR DESCRIPTION
This PR adds the "insurance_agency" AddressComponentType. It's present as a PlaceType and AddressType, but not an AddressComponentType, and in testing, I've seen it show up in AddressComponentType.