### PR TITLE
Add AddressComponentTypes: car_rental, painter

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -166,6 +166,12 @@ public enum AddressComponentType {
   /** The location of a light rail station. */
   LIGHT_RAIL_STATION("light_rail_station"),
 
+  /** A car rental establishment. */
+  CAR_RENTAL("car_rental"),
+
+  /** A painter. */
+  PAINTER("painter"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.


### PR DESCRIPTION
Adds two now AddressComponentTypes

* car_rental
* painter

Discovered through [fuzz testing using gmsj-cli](https://github.com/apjanke/gmsj-cli/commit/d4de21a663405a6cc4abbc020a75253e4926bae7).

```
$ ./bin/geofuzz-and-show-new-types "World Trade Center, NY" -r 0.1 -n 1000
Searching 1000 points around 'World Trade Center, NY', with radius 0.100000 degrees (rand seed 42)
Possible new types:
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'car_rental'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'general_contractor'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'lodging'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'painter'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'real_estate_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'store'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressComponentType: 'travel_agency'
[main] WARN com.google.maps.internal.SafeEnumAdapter - Unknown type for enum com.google.maps.model.AddressType: 'general_contractor'
```