### PR TITLE
Add Javadoc for DirectionsApiRequest static methods

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApi.java
+++ b/src/main/java/com/google/maps/DirectionsApi.java
@@ -38,10 +38,24 @@ public class DirectionsApi {
 
   private DirectionsApi() {}
 
+  /**
+   * Creates a new DirectionsApiRequest using the given context, with all attributes
+   * at their default values.
+   * @param context Context that the DirectionsApiRequest will be executed against
+   * @return A newly constructed DirectionsApiRequest between the given points.
+   */
   public static DirectionsApiRequest newRequest(GeoApiContext context) {
     return new DirectionsApiRequest(context);
   }
 
+  /**
+   * Creates a new DirectionsApiRequest between the given origin and destination, using
+   * the defaults for all other options.
+   * @param context Context that the DirectionsApiRequest will be executed against
+   * @param origin Origin address as text
+   * @param destination Destination address as text
+   * @return A newly constructed DirectionsApiRequest between the given points.
+   */
   public static DirectionsApiRequest getDirections(
       GeoApiContext context, String origin, String destination) {
     return new DirectionsApiRequest(context).origin(origin).destination(destination);


### PR DESCRIPTION
I don't know if you want Javadoc that's this detailed, but there's a couple public static methods on DirectionsApiRequest that lack Javadoc comments. I found the lack of doco for `getDirections` a bit confusing when I was trying to use it myself today.