### PR TITLE
LocalTestServerContext: use "expected[s]" as assertion parameter name

### DIFF
--- a/src/test/java/com/google/maps/LocalTestServerContext.java
+++ b/src/test/java/com/google/maps/LocalTestServerContext.java
@@ -102,7 +102,7 @@ public class LocalTestServerContext implements AutoCloseable {
     return request.getPath().split("\\?")[0];
   }
 
-  void assertParamValue(String expectedValue, String paramName)
+  void assertParamValue(String expected, String paramName)
       throws URISyntaxException, InterruptedException {
     if (this.params == null) {
       this.params = this.actualParams();
@@ -111,13 +111,13 @@ public class LocalTestServerContext implements AutoCloseable {
     for (NameValuePair pair : params) {
       if (pair.getName().equals(paramName)) {
         paramFound = true;
-        assertEquals(expectedValue, pair.getValue());
+        assertEquals(expected, pair.getValue());
       }
     }
     assertTrue(paramFound);
   }
 
-  void assertParamValues(List<String> expectedValues, String paramName)
+  void assertParamValues(List<String> expecteds, String paramName)
       throws URISyntaxException, InterruptedException {
     if (this.params == null) {
       this.params = this.actualParams();
@@ -125,11 +125,11 @@ public class LocalTestServerContext implements AutoCloseable {
     int paramsFound = 0;
     for (NameValuePair pair : params) {
       if (pair.getName().equals(paramName)) {
-        assertEquals(expectedValues.get(paramsFound), pair.getValue());
+        assertEquals(expecteds.get(paramsFound), pair.getValue());
         paramsFound++;
       }
     }
-    assertEquals(paramsFound, expectedValues.size());
+    assertEquals(paramsFound, expecteds.size());
   }
 
   @Override


### PR DESCRIPTION
Would you consider using just "expected" and "expecteds" as the assertion method parameter names, instead of "expectedValue" and "expectedValues"? This improves consistency with JUnit Assert's own methods, which use "expected" and "expecteds", and, imho, improves readability in IDEs like IntelliJ which display inline parameter name hints.

No behavior changes in this PR, just a refactor for readability.