### PR TITLE
Minor code hygiene suggestions

### DIFF
--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -63,8 +63,8 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw (new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+    return new GaePendingResult<>(
+            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override
@@ -89,8 +89,8 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       throw (new RuntimeException(e));
     }
 
-    return new GaePendingResult<T, R>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+    return new GaePendingResult<>(
+            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override

--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -64,7 +64,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
     }
 
     return new GaePendingResult<>(
-            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override
@@ -90,7 +90,7 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
     }
 
     return new GaePendingResult<>(
-            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override

--- a/src/main/java/com/google/maps/GeolocationApiRequest.java
+++ b/src/main/java/com/google/maps/GeolocationApiRequest.java
@@ -37,7 +37,7 @@ public class GeolocationApiRequest
   @Override
   protected void validateRequest() {
     if (this.payload.considerIp != null
-        && this.payload.considerIp == false
+        && !this.payload.considerIp
         && this.payload.wifiAccessPoints != null
         && this.payload.wifiAccessPoints.length < 2) {
       throw new IllegalArgumentException("Request must contain two or more 'Wifi Access Points'");

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -63,8 +63,8 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
     Request req =
         new Request.Builder().get().header("User-Agent", userAgent).url(hostName + url).build();
 
-    return new OkHttpPendingResult<T, R>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+    return new OkHttpPendingResult<>(
+            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override
@@ -86,8 +86,8 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
             .url(hostName + url)
             .build();
 
-    return new OkHttpPendingResult<T, R>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+    return new OkHttpPendingResult<>(
+            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   public void shutdown() {

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -64,7 +64,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
         new Request.Builder().get().header("User-Agent", userAgent).url(hostName + url).build();
 
     return new OkHttpPendingResult<>(
-            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   @Override
@@ -87,7 +87,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
             .build();
 
     return new OkHttpPendingResult<>(
-            req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
   }
 
   public void shutdown() {

--- a/src/main/java/com/google/maps/StaticMapsRequest.java
+++ b/src/main/java/com/google/maps/StaticMapsRequest.java
@@ -167,7 +167,7 @@ public class StaticMapsRequest
 
   public static class Markers implements UrlValue {
 
-    public static enum MarkersSize implements UrlValue {
+    public enum MarkersSize implements UrlValue {
       tiny,
       mid,
       small,
@@ -179,7 +179,7 @@ public class StaticMapsRequest
       }
     }
 
-    public static enum CustomIconAnchor implements UrlValue {
+    public enum CustomIconAnchor implements UrlValue {
       top,
       bottom,
       left,

--- a/src/main/java/com/google/maps/internal/GaePendingResult.java
+++ b/src/main/java/com/google/maps/internal/GaePendingResult.java
@@ -172,16 +172,11 @@ public class GaePendingResult<T, R extends ApiResponse<T>> implements PendingRes
             .registerTypeAdapter(Fare.class, new FareAdapter())
             .registerTypeAdapter(LatLng.class, new LatLngAdapter())
             .registerTypeAdapter(
-                AddressComponentType.class,
-                    new SafeEnumAdapter<>(AddressComponentType.UNKNOWN))
-            .registerTypeAdapter(
-                AddressType.class, new SafeEnumAdapter<>(AddressType.UNKNOWN))
-            .registerTypeAdapter(
-                TravelMode.class, new SafeEnumAdapter<>(TravelMode.UNKNOWN))
-            .registerTypeAdapter(
-                LocationType.class, new SafeEnumAdapter<>(LocationType.UNKNOWN))
-            .registerTypeAdapter(
-                RatingType.class, new SafeEnumAdapter<>(RatingType.UNKNOWN))
+                AddressComponentType.class, new SafeEnumAdapter<>(AddressComponentType.UNKNOWN))
+            .registerTypeAdapter(AddressType.class, new SafeEnumAdapter<>(AddressType.UNKNOWN))
+            .registerTypeAdapter(TravelMode.class, new SafeEnumAdapter<>(TravelMode.UNKNOWN))
+            .registerTypeAdapter(LocationType.class, new SafeEnumAdapter<>(LocationType.UNKNOWN))
+            .registerTypeAdapter(RatingType.class, new SafeEnumAdapter<>(RatingType.UNKNOWN))
             .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdapter())
             .registerTypeAdapter(PriceLevel.class, new PriceLevelAdapter())
             .registerTypeAdapter(Instant.class, new InstantAdapter())

--- a/src/main/java/com/google/maps/internal/GaePendingResult.java
+++ b/src/main/java/com/google/maps/internal/GaePendingResult.java
@@ -173,15 +173,15 @@ public class GaePendingResult<T, R extends ApiResponse<T>> implements PendingRes
             .registerTypeAdapter(LatLng.class, new LatLngAdapter())
             .registerTypeAdapter(
                 AddressComponentType.class,
-                new SafeEnumAdapter<AddressComponentType>(AddressComponentType.UNKNOWN))
+                    new SafeEnumAdapter<>(AddressComponentType.UNKNOWN))
             .registerTypeAdapter(
-                AddressType.class, new SafeEnumAdapter<AddressType>(AddressType.UNKNOWN))
+                AddressType.class, new SafeEnumAdapter<>(AddressType.UNKNOWN))
             .registerTypeAdapter(
-                TravelMode.class, new SafeEnumAdapter<TravelMode>(TravelMode.UNKNOWN))
+                TravelMode.class, new SafeEnumAdapter<>(TravelMode.UNKNOWN))
             .registerTypeAdapter(
-                LocationType.class, new SafeEnumAdapter<LocationType>(LocationType.UNKNOWN))
+                LocationType.class, new SafeEnumAdapter<>(LocationType.UNKNOWN))
             .registerTypeAdapter(
-                RatingType.class, new SafeEnumAdapter<RatingType>(RatingType.UNKNOWN))
+                RatingType.class, new SafeEnumAdapter<>(RatingType.UNKNOWN))
             .registerTypeAdapter(DayOfWeek.class, new DayOfWeekAdapter())
             .registerTypeAdapter(PriceLevel.class, new PriceLevelAdapter())
             .registerTypeAdapter(Instant.class, new InstantAdapter())

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -153,7 +153,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
       }
     }
 
-    final BlockingQueue<QueuedResponse> waiter = new ArrayBlockingQueue<QueuedResponse>(1);
+    final BlockingQueue<QueuedResponse> waiter = new ArrayBlockingQueue<>(1);
     final OkHttpPendingResult<T, R> parent = this;
 
     // This callback will be called on another thread, handled by the RateLimitExecutorService.

--- a/src/main/java/com/google/maps/internal/PolylineEncoding.java
+++ b/src/main/java/com/google/maps/internal/PolylineEncoding.java
@@ -32,7 +32,7 @@ public class PolylineEncoding {
 
     int len = encodedPath.length();
 
-    final List<LatLng> path = new ArrayList<LatLng>(len / 2);
+    final List<LatLng> path = new ArrayList<>(len / 2);
     int index = 0;
     int lat = 0;
     int lng = 0;

--- a/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
+++ b/src/main/java/com/google/maps/internal/RateLimitExecutorService.java
@@ -51,7 +51,7 @@ public class RateLimitExecutorService implements ExecutorService, Runnable {
           new SynchronousQueue<Runnable>(),
           threadFactory("Rate Limited Dispatcher", true));
 
-  private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
+  private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
   private final RateLimiter rateLimiter =
       RateLimiter.create(DEFAULT_QUERIES_PER_SECOND, 1, TimeUnit.SECONDS);
 

--- a/src/main/java/com/google/maps/internal/ratelimiter/RateLimiter.java
+++ b/src/main/java/com/google/maps/internal/ratelimiter/RateLimiter.java
@@ -408,7 +408,7 @@ public abstract class RateLimiter {
 
     protected abstract void sleepMicrosUninterruptibly(long micros);
 
-    public static final SleepingStopwatch createFromSystemTimer() {
+    public static SleepingStopwatch createFromSystemTimer() {
       return new SleepingStopwatch() {
         final Stopwatch stopwatch = Stopwatch.createStarted();
 

--- a/src/main/java/com/google/maps/model/CellTower.java
+++ b/src/main/java/com/google/maps/model/CellTower.java
@@ -101,37 +101,37 @@ public class CellTower implements Serializable {
     }
 
     public CellTowerBuilder CellId(int newCellId) {
-      this._cellId = new Integer(newCellId);
+      this._cellId = newCellId;
       return this;
     }
 
     public CellTowerBuilder LocationAreaCode(int newLocationAreaCode) {
-      this._locationAreaCode = new Integer(newLocationAreaCode);
+      this._locationAreaCode = newLocationAreaCode;
       return this;
     }
 
     public CellTowerBuilder MobileCountryCode(int newMobileCountryCode) {
-      this._mobileCountryCode = new Integer(newMobileCountryCode);
+      this._mobileCountryCode = newMobileCountryCode;
       return this;
     }
 
     public CellTowerBuilder MobileNetworkCode(int newMobileNetworkCode) {
-      this._mobileNetworkCode = new Integer(newMobileNetworkCode);
+      this._mobileNetworkCode = newMobileNetworkCode;
       return this;
     }
 
     public CellTowerBuilder Age(int newAge) {
-      this._age = new Integer(newAge);
+      this._age = newAge;
       return this;
     }
 
     public CellTowerBuilder SignalStrength(int newSignalStrength) {
-      this._signalStrength = new Integer(newSignalStrength);
+      this._signalStrength = newSignalStrength;
       return this;
     }
 
     public CellTowerBuilder TimingAdvance(int newTimingAdvance) {
-      this._timingAdvance = new Integer(newTimingAdvance);
+      this._timingAdvance = newTimingAdvance;
       return this;
     }
   }

--- a/src/main/java/com/google/maps/model/GeolocationPayload.java
+++ b/src/main/java/com/google/maps/model/GeolocationPayload.java
@@ -110,12 +110,12 @@ public class GeolocationPayload implements Serializable {
     }
 
     public GeolocationPayloadBuilder HomeMobileCountryCode(int newHomeMobileCountryCode) {
-      this._homeMobileCountryCode = new Integer(newHomeMobileCountryCode);
+      this._homeMobileCountryCode = newHomeMobileCountryCode;
       return this;
     }
 
     public GeolocationPayloadBuilder HomeMobileNetworkCode(int newHomeMobileNetworkCode) {
-      this._homeMobileNetworkCode = new Integer(newHomeMobileNetworkCode);
+      this._homeMobileNetworkCode = newHomeMobileNetworkCode;
       return this;
     }
 
@@ -130,7 +130,7 @@ public class GeolocationPayload implements Serializable {
     }
 
     public GeolocationPayloadBuilder ConsiderIp(boolean newConsiderIp) {
-      this._considerIp = new Boolean(newConsiderIp);
+      this._considerIp = newConsiderIp;
       return this;
     }
 

--- a/src/main/java/com/google/maps/model/GeolocationPayload.java
+++ b/src/main/java/com/google/maps/model/GeolocationPayload.java
@@ -83,9 +83,9 @@ public class GeolocationPayload implements Serializable {
     private String _carrier = null;
     private Boolean _considerIp = null;
     private CellTower[] _cellTowers = null;
-    private List<CellTower> _addedCellTowers = new ArrayList<CellTower>();
+    private List<CellTower> _addedCellTowers = new ArrayList<>();
     private WifiAccessPoint[] _wifiAccessPoints = null;
-    private List<WifiAccessPoint> _addedWifiAccessPoints = new ArrayList<WifiAccessPoint>();
+    private List<WifiAccessPoint> _addedWifiAccessPoints = new ArrayList<>();
 
     public GeolocationPayload createGeolocationPayload() {
       // if wifi access points have been added individually...

--- a/src/main/java/com/google/maps/model/WifiAccessPoint.java
+++ b/src/main/java/com/google/maps/model/WifiAccessPoint.java
@@ -79,22 +79,22 @@ public class WifiAccessPoint implements Serializable {
     }
 
     public WifiAccessPointBuilder SignalStrength(int newSignalStrength) {
-      this._signalStrength = new Integer(newSignalStrength);
+      this._signalStrength = newSignalStrength;
       return this;
     }
 
     public WifiAccessPointBuilder Age(int newAge) {
-      this._age = new Integer(newAge);
+      this._age = newAge;
       return this;
     }
 
     public WifiAccessPointBuilder Channel(int newChannel) {
-      this._channel = new Integer(newChannel);
+      this._channel = newChannel;
       return this;
     }
 
     public WifiAccessPointBuilder SignalToNoiseRatio(int newSignalToNoiseRatio) {
-      this._signalToNoiseRatio = new Integer(newSignalToNoiseRatio);
+      this._signalToNoiseRatio = newSignalToNoiseRatio;
       return this;
     }
   }

--- a/src/test/java/com/google/maps/DirectionsApiTest.java
+++ b/src/test/java/com/google/maps/DirectionsApiTest.java
@@ -290,7 +290,7 @@ public class DirectionsApiTest {
   @Test
   public void testTrafficModel() throws Exception {
     try (LocalTestServerContext sc =
-        new LocalTestServerContext("{\"routes\": [{}],\"status\": \"OK\"}"); ) {
+        new LocalTestServerContext("{\"routes\": [{}],\"status\": \"OK\"}")) {
       DirectionsApi.newRequest(sc.context)
           .origin("48 Pirrama Road, Pyrmont NSW 2009")
           .destination("182 Church St, Parramatta NSW 2150")
@@ -349,7 +349,7 @@ public class DirectionsApiTest {
   @Test
   public void testTravelModeWalking() throws Exception {
     try (LocalTestServerContext sc =
-        new LocalTestServerContext("{\"routes\": [{}],\"status\": \"OK\"}"); ) {
+        new LocalTestServerContext("{\"routes\": [{}],\"status\": \"OK\"}")) {
       DirectionsResult result =
           DirectionsApi.newRequest(sc.context)
               .mode(TravelMode.WALKING)

--- a/src/test/java/com/google/maps/DirectionsApiTest.java
+++ b/src/test/java/com/google/maps/DirectionsApiTest.java
@@ -483,7 +483,7 @@ public class DirectionsApiTest {
 
   /** Coordinates in Mexico City. */
   private List<LatLng> getOptimizationWaypoints() {
-    List<LatLng> waypoints = new ArrayList<LatLng>();
+    List<LatLng> waypoints = new ArrayList<>();
     waypoints.add(new LatLng(19.431676, -99.133999));
     waypoints.add(new LatLng(19.427915, -99.138939));
     waypoints.add(new LatLng(19.435436, -99.139145));

--- a/src/test/java/com/google/maps/GeocodingApiTest.java
+++ b/src/test/java/com/google/maps/GeocodingApiTest.java
@@ -92,7 +92,7 @@ public class GeocodingApiTest {
   @Test
   public void testAsync() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext(simpleGeocodeResponse)) {
-      final List<GeocodingResult[]> resps = new ArrayList<GeocodingResult[]>();
+      final List<GeocodingResult[]> resps = new ArrayList<>();
 
       PendingResult.Callback<GeocodingResult[]> callback =
           new PendingResult.Callback<GeocodingResult[]>() {

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -305,7 +305,6 @@ public class PlacesApiTest {
       assertEquals("en", review.language);
       assertNotNull(review.relativeTimeDescription);
       assertEquals("a month ago", review.relativeTimeDescription);
-      assertNotNull(review.rating);
       assertEquals(5, review.rating);
       assertNotNull(review.text);
       assertTrue(review.text.startsWith("As someone who works in the theatre,"));

--- a/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
+++ b/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
@@ -41,7 +41,7 @@ public class RateLimitExecutorServiceTest {
     RateLimitExecutorService service = new RateLimitExecutorService();
     service.setQueriesPerSecond(qps);
     final ConcurrentHashMap<Integer, Integer> executedTimestamps =
-        new ConcurrentHashMap<Integer, Integer>();
+        new ConcurrentHashMap<>();
 
     for (int i = 0; i < 100; i++) {
       Runnable emptyTask =

--- a/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
+++ b/src/test/java/com/google/maps/internal/RateLimitExecutorServiceTest.java
@@ -40,8 +40,7 @@ public class RateLimitExecutorServiceTest {
     int qps = 10;
     RateLimitExecutorService service = new RateLimitExecutorService();
     service.setQueriesPerSecond(qps);
-    final ConcurrentHashMap<Integer, Integer> executedTimestamps =
-        new ConcurrentHashMap<>();
+    final ConcurrentHashMap<Integer, Integer> executedTimestamps = new ConcurrentHashMap<>();
 
     for (int i = 0; i < 100; i++) {
       Runnable emptyTask =

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -39,7 +39,7 @@ public class EnumsTest {
 
   @Test
   public void testCanonicalLiteralsForAddressType() {
-    Map<AddressType, String> addressTypeToLiteralMap = new HashMap<AddressType, String>();
+    Map<AddressType, String> addressTypeToLiteralMap = new HashMap<>();
     addressTypeToLiteralMap.put(AddressType.STREET_ADDRESS, "street_address");
     addressTypeToLiteralMap.put(AddressType.ROUTE, "route");
     addressTypeToLiteralMap.put(AddressType.INTERSECTION, "intersection");
@@ -94,7 +94,7 @@ public class EnumsTest {
   @Test
   public void testCanonicalLiteralsForAddressComponentType() {
     Map<AddressComponentType, String> addressComponentTypeToLiteralMap =
-        new HashMap<AddressComponentType, String>();
+            new HashMap<>();
     addressComponentTypeToLiteralMap.put(AddressComponentType.STREET_ADDRESS, "street_address");
     addressComponentTypeToLiteralMap.put(AddressComponentType.ROUTE, "route");
     addressComponentTypeToLiteralMap.put(AddressComponentType.INTERSECTION, "intersection");

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -93,8 +93,7 @@ public class EnumsTest {
 
   @Test
   public void testCanonicalLiteralsForAddressComponentType() {
-    Map<AddressComponentType, String> addressComponentTypeToLiteralMap =
-            new HashMap<>();
+    Map<AddressComponentType, String> addressComponentTypeToLiteralMap = new HashMap<>();
     addressComponentTypeToLiteralMap.put(AddressComponentType.STREET_ADDRESS, "street_address");
     addressComponentTypeToLiteralMap.put(AddressComponentType.ROUTE, "route");
     addressComponentTypeToLiteralMap.put(AddressComponentType.INTERSECTION, "intersection");


### PR DESCRIPTION
This PR contains some suggestions for minor code hygiene changes. No behavior changes; just refactoring, mostly to use newer post-Java-1.5 stuff.

* Removes unnecessary explicit primitive value boxing
* Uses the diamond operator for parameterized type inference where possible
* Removes redundant `static` and `final` modifiers
* Removes a couple unnecessary pieces of syntax

This PR is split up into separate commits for each type of change, to make review easier.