### PR TITLE
Replace bogus @url Javadoc tag with HTML link

### DIFF
--- a/src/main/java/com/google/maps/internal/PolylineEncoding.java
+++ b/src/main/java/com/google/maps/internal/PolylineEncoding.java
@@ -23,8 +23,9 @@ import java.util.List;
 /**
  * Utility class that encodes and decodes Polylines.
  *
- * <p>See {@url https://developers.google.com/maps/documentation/utilities/polylinealgorithm} for
- * detailed description of this format.
+ * <p>See <a href="https://developers.google.com/maps/documentation/utilities/polylinealgorithm">
+ * https://developers.google.com/maps/documentation/utilities/polylinealgorithm</a> for detailed
+ * description of this format.
  */
 public class PolylineEncoding {
   /** Decodes an encoded path string into a sequence of LatLngs. */


### PR DESCRIPTION
As far as I know, `@url` is not a standard Javadoc tag type, and I don't see a custom tag definition for it in this project.

This PR replaces a use of `@url` with a regular HTML link. It's in an `internal` class, so it won't show up in the generated Javadoc and doesn't actually matter, but it gets rid of a warning in static inspection tools that validate Javadoc.