### PR TITLE
Adjust link in README so Markdown inspectors do not complain

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The `GeoApiContext` is designed to be a [Singleton](https://en.wikipedia.org/wik
 in your application. Please instantiate one on application startup, and continue to use it for the
 life of your application. This will enable proper QPS enforcement across all of your requests.
 
-For more usage examples, check out [the tests](src/test/java/com/google/maps/).
+For more usage examples, check out [the tests](src/test/java/com/google/maps).
 
 ## Features
 


### PR DESCRIPTION
The current trailing slash causes some Markdown validators to complain about
being "unable to resolve file ''".