### PR TITLE
Add value-based toString()s for model objects

### DIFF
--- a/src/main/java/com/google/maps/internal/StringJoin.java
+++ b/src/main/java/com/google/maps/internal/StringJoin.java
@@ -15,6 +15,8 @@
 
 package com.google.maps.internal;
 
+import java.util.Objects;
+
 /** Utility class to join strings. */
 public class StringJoin {
 
@@ -30,12 +32,31 @@ public class StringJoin {
   private StringJoin() {}
 
   public static String join(char delim, String... parts) {
+    return join(new String(new char[] {delim}), parts);
+  }
+
+  public static String join(CharSequence delim, String... parts) {
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < parts.length; i++) {
       if (i != 0) {
         result.append(delim);
       }
       result.append(parts[i]);
+    }
+    return result.toString();
+  }
+
+  public static String join(char delim, Object... parts) {
+    return join(new String(new char[] {delim}), parts);
+  }
+
+  public static String join(CharSequence delim, Object... parts) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i != 0) {
+        result.append(delim);
+      }
+      result.append(Objects.toString(parts[i]));
     }
     return result.toString();
   }

--- a/src/main/java/com/google/maps/model/AddressComponent.java
+++ b/src/main/java/com/google/maps/model/AddressComponent.java
@@ -15,6 +15,8 @@
 
 package com.google.maps.model;
 
+import static com.google.maps.internal.StringJoin.join;
+
 import java.io.Serializable;
 
 /**
@@ -41,4 +43,15 @@ public class AddressComponent implements Serializable {
 
   /** Indicates the type of each part of the address. Examples include street number or country. */
   public AddressComponentType[] types;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[AddressComponent: ");
+    sb.append("\"").append(longName).append("\"");
+    if (shortName != null) {
+      sb.append(" (\"").append(shortName).append("\")");
+    }
+    sb.append(" (").append(join(", ", (Object[]) types)).append(")");
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/AutocompletePrediction.java
+++ b/src/main/java/com/google/maps/model/AutocompletePrediction.java
@@ -16,6 +16,8 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Represents a single Autocomplete result returned from the Google Places API Web Service.
@@ -61,6 +63,10 @@ public class AutocompletePrediction implements Serializable {
 
     /** The start position of the matched substring, measured in Unicode characters. */
     public int offset;
+
+    public String toString() {
+      return String.format("(offset=%d, length=%d)", offset, length);
+    }
   }
 
   /**
@@ -83,5 +89,21 @@ public class AutocompletePrediction implements Serializable {
 
     /** The text of the matched term. */
     public String value;
+
+    public String toString() {
+      return String.format("(offset=%d, value=%s)", offset, value);
+    }
+  }
+
+  public String toString() {
+    return String.format(
+        "[AutocompletePrediction: \"%s\", placeId=%s, types=%s, terms=%s, "
+            + "matchedSubstrings=%s, structuredFormatting=%s]",
+        description,
+        placeId,
+        Arrays.toString(types),
+        Arrays.toString(terms),
+        Arrays.toString(matchedSubstrings),
+        Objects.toString(structuredFormatting));
   }
 }

--- a/src/main/java/com/google/maps/model/AutocompleteStructuredFormatting.java
+++ b/src/main/java/com/google/maps/model/AutocompleteStructuredFormatting.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /** The structured formatting info for a {@link com.google.maps.model.AutocompletePrediction}. */
 public class AutocompleteStructuredFormatting implements Serializable {
@@ -30,4 +31,15 @@ public class AutocompleteStructuredFormatting implements Serializable {
 
   /** The secondary text of a prediction, usually the location of the place. */
   public String secondaryText;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("(");
+    sb.append("\"").append(mainText).append("\"");
+    sb.append(" at ").append(Arrays.toString(mainTextMatchedSubstrings));
+    if (secondaryText != null) {
+      sb.append(", secondaryText=\"").append(secondaryText).append("\"");
+    }
+    sb.append(")");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/Bounds.java
+++ b/src/main/java/com/google/maps/model/Bounds.java
@@ -25,4 +25,8 @@ public class Bounds implements Serializable {
   public LatLng northeast;
   /** The southwest corner of the bounding box. */
   public LatLng southwest;
+
+  public String toString() {
+    return String.format("[%s, %s]", northeast, southwest);
+  }
 }

--- a/src/main/java/com/google/maps/model/CellTower.java
+++ b/src/main/java/com/google/maps/model/CellTower.java
@@ -79,6 +79,19 @@ public class CellTower implements Serializable {
   /** The timing advance value. */
   public Integer timingAdvance = null;
 
+  public String toString() {
+    return String.format(
+        "[CellTower: cellId=%s, locationAreaCode=%s, mobileCountryCode=%s, "
+            + "mobileNetworkCode=%s, age=%s, signalStrength=%s, timingAdvance=%s]",
+        cellId,
+        locationAreaCode,
+        mobileCountryCode,
+        mobileNetworkCode,
+        age,
+        signalStrength,
+        timingAdvance);
+  }
+
   public static class CellTowerBuilder {
     private Integer _cellId = null;
     private Integer _locationAreaCode = null;

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -93,4 +93,25 @@ public class DirectionsLeg implements Serializable {
    * leg.
    */
   public String endAddress;
+
+  public String toString() {
+    StringBuilder sb =
+        new StringBuilder(
+            String.format(
+                "[DirectionsLeg: \"%s\" -> \"%s\" (%s -> %s)",
+                startAddress, endAddress, startLocation, endLocation));
+    if (departureTime != null) {
+      sb.append(", departureTime=").append(departureTime);
+    }
+    if (arrivalTime != null) {
+      sb.append(", arrivalTime=").append(arrivalTime);
+    }
+    if (durationInTraffic != null) {
+      sb.append(", durationInTraffic=").append(durationInTraffic);
+    }
+    sb.append(", duration=").append(duration);
+    sb.append(", distance=").append(distance);
+    sb.append(": ").append(steps.length).append(" steps]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/DirectionsRoute.java
+++ b/src/main/java/com/google/maps/model/DirectionsRoute.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * A Directions API result. When the Directions API returns results, it places them within a routes
@@ -71,4 +72,19 @@ public class DirectionsRoute implements Serializable {
    * warnings yourself.
    */
   public String[] warnings;
+
+  public String toString() {
+    String str =
+        String.format(
+            "[DirectionsRoute: \"%s\", %d legs, waypointOrder=%s, bounds=%s",
+            summary, legs.length, Arrays.toString(waypointOrder), bounds);
+    if (fare != null) {
+      str = str + ", fare=" + fare;
+    }
+    if (warnings != null && warnings.length > 0) {
+      str = str + ", " + warnings.length + " warnings";
+    }
+    str = str + "]";
+    return str;
+  }
 }

--- a/src/main/java/com/google/maps/model/DirectionsStep.java
+++ b/src/main/java/com/google/maps/model/DirectionsStep.java
@@ -84,4 +84,19 @@ public class DirectionsStep implements Serializable {
    * Details</a> for more detail.
    */
   public TransitDetails transitDetails;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[DirectionsStep: ");
+    sb.append("\"").append(htmlInstructions).append("\"");
+    sb.append(String.format(" (%s -> %s", startLocation, endLocation)).append(")");
+    sb.append(" ").append(travelMode);
+    sb.append(", duration=").append(duration);
+    sb.append(", distance=").append(distance);
+    sb.append(", ").append(steps.length).append(" steps");
+    if (transitDetails != null) {
+      sb.append(", transitDetails=").append(transitDetails);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/DistanceMatrix.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrix.java
@@ -51,4 +51,10 @@ public class DistanceMatrix implements Serializable {
     this.destinationAddresses = destinationAddresses;
     this.rows = rows;
   }
+
+  public String toString() {
+    return String.format(
+        "DistanceMatrix: %d origins x %d destinations, %d rows",
+        originAddresses.length, destinationAddresses.length, rows.length);
+  }
 }

--- a/src/main/java/com/google/maps/model/DistanceMatrixElement.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixElement.java
@@ -56,4 +56,18 @@ public class DistanceMatrixElement implements Serializable {
 
   /** {@code fare} contains information about the fare (that is, the ticket costs) on this route. */
   public Fare fare;
+
+  public String toString() {
+    String str =
+        String.format(
+            "[DistanceMatrixElement %s distance=%s, duration=%s", status, distance, duration);
+    if (durationInTraffic != null) {
+      str = str + ", durationInTraffic=" + durationInTraffic;
+    }
+    if (fare != null) {
+      str = str + ", fare=" + fare;
+    }
+    str = str + "]";
+    return str;
+  }
 }

--- a/src/main/java/com/google/maps/model/DistanceMatrixRow.java
+++ b/src/main/java/com/google/maps/model/DistanceMatrixRow.java
@@ -27,4 +27,8 @@ public class DistanceMatrixRow implements Serializable {
 
   /** The results for this row, or individual origin. */
   public DistanceMatrixElement[] elements;
+
+  public String toString() {
+    return String.format("[DistanceMatrixRow %d elements]", elements.length);
+  }
 }

--- a/src/main/java/com/google/maps/model/ElevationResult.java
+++ b/src/main/java/com/google/maps/model/ElevationResult.java
@@ -17,12 +17,23 @@ package com.google.maps.model;
 
 import java.io.Serializable;
 
-/** An Elevation API result. */
+/**
+ * An Elevation API result.
+ *
+ * <p>Units are in meters, per https://developers.google.com/maps/documentation/elevation/start.
+ */
 public class ElevationResult implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  /** Elevation in meters. */
   public double elevation;
+  /** Location of the elevation data. */
   public LatLng location;
+  /** Maximum distance between data points from which the elevation was interpolated, in meters. */
   public double resolution;
+
+  public String toString() {
+    return String.format("(%s, %f m, resolution=%f m)", location, elevation, resolution);
+  }
 }

--- a/src/main/java/com/google/maps/model/EncodedPolyline.java
+++ b/src/main/java/com/google/maps/model/EncodedPolyline.java
@@ -50,4 +50,10 @@ public class EncodedPolyline implements Serializable {
   public List<LatLng> decodePath() {
     return PolylineEncoding.decode(points);
   }
+
+  // Use the encoded point representation; decoding to get an alternate representation for
+  // individual points would be expensive.
+  public String toString() {
+    return String.format("[EncodedPolyline: %s]", points);
+  }
 }

--- a/src/main/java/com/google/maps/model/Fare.java
+++ b/src/main/java/com/google/maps/model/Fare.java
@@ -34,4 +34,8 @@ public class Fare implements Serializable {
 
   /** The total fare amount, in the currency specified in {@link #currency}. */
   public BigDecimal value;
+
+  public String toString() {
+    return String.format("%s %s", value, currency);
+  }
 }

--- a/src/main/java/com/google/maps/model/FindPlaceFromText.java
+++ b/src/main/java/com/google/maps/model/FindPlaceFromText.java
@@ -22,4 +22,8 @@ public class FindPlaceFromText implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public PlacesSearchResult candidates[];
+
+  public String toString() {
+    return String.format("[FindPlaceFromText %d candidates]", candidates.length);
+  }
 }

--- a/src/main/java/com/google/maps/model/GeocodedWaypoint.java
+++ b/src/main/java/com/google/maps/model/GeocodedWaypoint.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * A point in a Directions API response; either the origin, one of the requested waypoints, or the
@@ -26,6 +27,7 @@ import java.io.Serializable;
 public class GeocodedWaypoint implements Serializable {
 
   private static final long serialVersionUID = 1L;
+
   /** The status code resulting from the geocoding operation for this waypoint. */
   public GeocodedWaypointStatus geocoderStatus;
 
@@ -40,4 +42,15 @@ public class GeocodedWaypoint implements Serializable {
 
   /** The address types of the geocoding result used for calculating directions. */
   public AddressType types[];
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[GeocodedWaypoint");
+    sb.append(" ").append(geocoderStatus);
+    if (partialMatch) {
+      sb.append(" ").append("PARTIAL MATCH");
+    }
+    sb.append(" placeId=").append(placeId);
+    sb.append(", types=").append(Arrays.toString(types));
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/GeocodingResult.java
+++ b/src/main/java/com/google/maps/model/GeocodingResult.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /** A result from a Geocoding API call. */
 public class GeocodingResult implements Serializable {
@@ -74,4 +75,21 @@ public class GeocodingResult implements Serializable {
 
   /** The Plus Code identifier for this place. */
   public PlusCode plusCode;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[GeocodingResult");
+    if (partialMatch) {
+      sb.append(" PARTIAL MATCH");
+    }
+    sb.append(" placeId=").append(placeId);
+    sb.append(" ").append(geometry);
+    sb.append(", formattedAddress=").append(formattedAddress);
+    sb.append(", types=").append(Arrays.toString(types));
+    sb.append(", addressComponents=").append(Arrays.toString(addressComponents));
+    if (postcodeLocalities != null && postcodeLocalities.length > 0) {
+      sb.append(", postcodeLocalities=").append(Arrays.toString(postcodeLocalities));
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/GeolocationPayload.java
+++ b/src/main/java/com/google/maps/model/GeolocationPayload.java
@@ -15,8 +15,11 @@
 
 package com.google.maps.model;
 
+import static com.google.maps.internal.StringJoin.join;
+
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -75,6 +78,33 @@ public class GeolocationPayload implements Serializable {
   public CellTower[] cellTowers;
   /** An array of WiFi access point objects. See {@link com.google.maps.model.WifiAccessPoint}. */
   public WifiAccessPoint[] wifiAccessPoints;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[GeolocationPayload");
+    List<String> elements = new ArrayList<>();
+    if (homeMobileCountryCode != null) {
+      elements.add("homeMobileCountryCode=" + homeMobileCountryCode);
+    }
+    if (homeMobileNetworkCode != null) {
+      elements.add("homeMobileNetworkCode=" + homeMobileNetworkCode);
+    }
+    if (radioType != null) {
+      elements.add("radioType=" + radioType);
+    }
+    if (carrier != null) {
+      elements.add("carrier=" + carrier);
+    }
+    elements.add("considerIp=" + considerIp);
+    if (cellTowers != null && cellTowers.length > 0) {
+      elements.add("cellTowers=" + Arrays.toString(cellTowers));
+    }
+    if (wifiAccessPoints != null && wifiAccessPoints.length > 0) {
+      elements.add("wifiAccessPoints=" + Arrays.toString(wifiAccessPoints));
+    }
+    sb.append(join(", ", elements));
+    sb.append("]");
+    return sb.toString();
+  }
 
   public static class GeolocationPayloadBuilder {
     private Integer _homeMobileCountryCode = null;

--- a/src/main/java/com/google/maps/model/GeolocationResult.java
+++ b/src/main/java/com/google/maps/model/GeolocationResult.java
@@ -36,4 +36,8 @@ public class GeolocationResult implements Serializable {
    * around the returned {@code location}.
    */
   public double accuracy;
+
+  public String toString() {
+    return String.format("%s, accuracy=%s m", location, accuracy);
+  }
 }

--- a/src/main/java/com/google/maps/model/Geometry.java
+++ b/src/main/java/com/google/maps/model/Geometry.java
@@ -43,4 +43,9 @@ public class Geometry implements Serializable {
    * frame a result when displaying it to a user.
    */
   public Bounds viewport;
+
+  public String toString() {
+    return String.format(
+        "[Geometry: %s (%s) bounds=%s, viewport=%s]", location, locationType, bounds, viewport);
+  }
 }

--- a/src/main/java/com/google/maps/model/OpeningHours.java
+++ b/src/main/java/com/google/maps/model/OpeningHours.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import org.joda.time.LocalTime;
 
 /**
@@ -43,19 +44,29 @@ public class OpeningHours implements Serializable {
       private static final long serialVersionUID = 1L;
 
       public enum DayOfWeek {
-        SUNDAY,
-        MONDAY,
-        TUESDAY,
-        WEDNESDAY,
-        THURSDAY,
-        FRIDAY,
-        SATURDAY,
+        SUNDAY("Sunday"),
+        MONDAY("Monday"),
+        TUESDAY("Tuesday"),
+        WEDNESDAY("Wednesday"),
+        THURSDAY("Thursday"),
+        FRIDAY("Friday"),
+        SATURDAY("Saturday"),
 
         /**
          * Indicates an unknown day of week type returned by the server. The Java Client for Google
          * Maps Services should be updated to support the new value.
          */
-        UNKNOWN
+        UNKNOWN("Unknown");
+
+        private DayOfWeek(String name) {
+          this.name = name;
+        }
+
+        private final String name;
+
+        public String getName() {
+          return name;
+        }
       }
 
       /** Day that this Open/Close pair is for. */
@@ -63,6 +74,10 @@ public class OpeningHours implements Serializable {
 
       /** Time that this Open or Close happens at. */
       public LocalTime time;
+
+      public String toString() {
+        return String.format("%s %s", day, time);
+      }
     }
 
     /** When the Place opens. */
@@ -70,6 +85,10 @@ public class OpeningHours implements Serializable {
 
     /** When the Place closes. */
     public Period.OpenClose close;
+
+    public String toString() {
+      return String.format("%s - %s", open, close);
+    }
   }
 
   /** Opening periods covering seven days, starting from Sunday, in chronological order. */
@@ -87,4 +106,16 @@ public class OpeningHours implements Serializable {
    * <p>Note: this field will be null if it isn't present in the response.
    */
   public Boolean permanentlyClosed;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[OpeningHours:");
+    if (permanentlyClosed != null && permanentlyClosed) {
+      sb.append(" permanentlyClosed");
+    }
+    if (openNow != null && openNow) {
+      sb.append(" openNow");
+    }
+    sb.append(" ").append(Arrays.toString(periods));
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/Photo.java
+++ b/src/main/java/com/google/maps/model/Photo.java
@@ -37,4 +37,13 @@ public class Photo implements Serializable {
 
   /** Attributions about this listing which must be displayed to the user. */
   public String[] htmlAttributions;
+
+  public String toString() {
+    String str = String.format("[Photo %s (%d x %d)", photoReference, width, height);
+    if (htmlAttributions != null && htmlAttributions.length > 0) {
+      str = str + " " + htmlAttributions.length + " attributions";
+    }
+    str = str + "]";
+    return str;
+  }
 }

--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -17,6 +17,7 @@ package com.google.maps.model;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.util.Arrays;
 import org.joda.time.Instant;
 
 /**
@@ -92,6 +93,10 @@ public class PlaceDetails implements Serializable {
      * place ID is recognised by your application only.
      */
     public PlaceIdScope scope;
+
+    public String toString() {
+      return String.format("%s (%s)", placeId, scope);
+    }
   }
 
   /**
@@ -213,4 +218,58 @@ public class PlaceDetails implements Serializable {
 
   /** Attributions about this listing which must be displayed to the user. */
   public String[] htmlAttributions;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[PlaceDetails: ");
+    sb.append("\"").append(name).append("\"");
+    sb.append(" ").append(placeId).append(" (").append(scope).append(")");
+    sb.append(" address=\"").append(formattedAddress).append("\"");
+    sb.append(" geometry=").append(geometry);
+    if (vicinity != null) {
+      sb.append(", vicinity=").append(vicinity);
+    }
+    if (types != null && types.length > 0) {
+      sb.append(", types=").append(Arrays.toString(types));
+    }
+    if (altIds != null && altIds.length > 0) {
+      sb.append(", altIds=").append(Arrays.toString(altIds));
+    }
+    if (formattedPhoneNumber != null) {
+      sb.append(", phone=").append(formattedPhoneNumber);
+    }
+    if (internationalPhoneNumber != null) {
+      sb.append(", internationalPhoneNumber=").append(internationalPhoneNumber);
+    }
+    if (url != null) {
+      sb.append(", url=").append(url);
+    }
+    if (website != null) {
+      sb.append(", website=").append(website);
+    }
+    if (icon != null) {
+      sb.append(", icon");
+    }
+    if (openingHours != null) {
+      sb.append(", openingHours");
+      sb.append(", utcOffset=").append(utcOffset);
+    }
+    if (priceLevel != null) {
+      sb.append(", priceLevel=").append(priceLevel);
+    }
+    sb.append(", rating=").append(rating);
+    if (permanentlyClosed) {
+      sb.append(", permanentlyClosed");
+    }
+    if (photos != null && photos.length > 0) {
+      sb.append(", ").append(photos.length).append(" photos");
+    }
+    if (reviews != null && reviews.length > 0) {
+      sb.append(", ").append(reviews.length).append(" reviews");
+    }
+    if (htmlAttributions != null && htmlAttributions.length > 0) {
+      sb.append(", ").append(htmlAttributions.length).append(" htmlAttributions");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/PlacesSearchResponse.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResponse.java
@@ -42,4 +42,17 @@ public class PlacesSearchResponse implements Serializable {
    * will become valid to execute.
    */
   public String nextPageToken;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[PlacesSearchResponse: ");
+    sb.append(results.length).append(" results");
+    if (nextPageToken != null) {
+      sb.append(", nextPageToken=").append(nextPageToken);
+    }
+    if (htmlAttributions != null && htmlAttributions.length > 0) {
+      sb.append(", ").append(htmlAttributions.length).append(" htmlAttributions");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/PlacesSearchResult.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResult.java
@@ -17,6 +17,7 @@ package com.google.maps.model;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.util.Arrays;
 
 /**
  * A single result in the search results returned from the Google Places API Web Service.
@@ -52,7 +53,7 @@ public class PlacesSearchResult implements Serializable {
   /** A textual identifier that uniquely identifies a place. */
   public String placeId;
 
-  /** sThe scope of the placeId. */
+  /** The scope of the placeId. */
   public PlaceIdScope scope;
 
   /** The place's rating, from 1.0 to 5.0, based on aggregated user reviews. */
@@ -72,4 +73,34 @@ public class PlacesSearchResult implements Serializable {
 
   /** Indicates that the place has permanently shut down. */
   public boolean permanentlyClosed;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[PlacesSearchResult: ");
+    sb.append("\"").append(name).append("\"");
+    sb.append(", \"").append(formattedAddress).append("\"");
+    sb.append(", geometry=").append(geometry);
+    sb.append(", placeId=").append(placeId).append(" (").append(scope).append(" )");
+    if (vicinity != null) {
+      sb.append(", vicinity=").append(vicinity);
+    }
+    if (types != null && types.length > 0) {
+      sb.append(", types=").append(Arrays.toString(types));
+    }
+    sb.append(", rating=").append(rating);
+    if (icon != null) {
+      sb.append(", icon");
+    }
+    if (openingHours != null) {
+      sb.append(", openingHours");
+    }
+    if (photos != null && photos.length > 0) {
+      sb.append(", ").append(photos.length).append(" photos");
+    }
+    if (permanentlyClosed) {
+      sb.append(", permanentlyClosed");
+    }
+
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/SnappedPoint.java
+++ b/src/main/java/com/google/maps/model/SnappedPoint.java
@@ -42,4 +42,8 @@ public class SnappedPoint implements Serializable {
    * that road segment.
    */
   public String placeId;
+
+  public String toString() {
+    return String.format("[%s, placeId=%s, originalIndex=%s]", location, placeId, originalIndex);
+  }
 }

--- a/src/main/java/com/google/maps/model/SnappedSpeedLimitResponse.java
+++ b/src/main/java/com/google/maps/model/SnappedSpeedLimitResponse.java
@@ -27,4 +27,16 @@ public class SnappedSpeedLimitResponse implements Serializable {
 
   /** Snap-to-road results. */
   public SnappedPoint[] snappedPoints;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[SnappedSpeedLimitResponse:");
+    if (speedLimits != null && speedLimits.length > 0) {
+      sb.append(" ").append(speedLimits.length).append(" speedLimits");
+    }
+    if (snappedPoints != null && snappedPoints.length > 0) {
+      sb.append(" ").append(snappedPoints.length).append(" speedLimits");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/SpeedLimit.java
+++ b/src/main/java/com/google/maps/model/SpeedLimit.java
@@ -38,4 +38,8 @@ public class SpeedLimit implements Serializable {
   public long speedLimitMph() {
     return Math.round(speedLimit * 0.621371);
   }
+
+  public String toString() {
+    return String.format("[%.0f km/h, placeId=%s]", speedLimit, placeId);
+  }
 }

--- a/src/main/java/com/google/maps/model/StopDetails.java
+++ b/src/main/java/com/google/maps/model/StopDetails.java
@@ -33,4 +33,8 @@ public class StopDetails implements Serializable {
 
   /** The location of the transit station/stop. */
   public LatLng location;
+
+  public String toString() {
+    return String.format("%s (%s)", name, location);
+  }
 }

--- a/src/main/java/com/google/maps/model/TransitAgency.java
+++ b/src/main/java/com/google/maps/model/TransitAgency.java
@@ -36,4 +36,17 @@ public class TransitAgency implements Serializable {
 
   /** The phone number of the transit agency. */
   public String phone;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[TransitAgency: ");
+    sb.append(name);
+    if (url != null) {
+      sb.append(", url=").append(url);
+    }
+    if (phone != null) {
+      sb.append(", phone=").append(phone);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -62,4 +62,21 @@ public class TransitDetails implements Serializable {
 
   /** Information about the transit line used in this step. */
   public TransitLine line;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[");
+    sb.append(departureStop).append(" at ").append(departureTime);
+    sb.append(" -> ");
+    sb.append(arrivalStop).append(" at ").append(arrivalTime);
+    if (headsign != null) {
+      sb.append(" (").append(headsign).append(" )");
+    }
+    if (line != null) {
+      sb.append(" on ").append(line);
+    }
+    sb.append(", ").append(numStops).append(" stops");
+    sb.append(", headway=").append(headway).append(" s");
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/google/maps/model/TransitLine.java
+++ b/src/main/java/com/google/maps/model/TransitLine.java
@@ -60,4 +60,8 @@ public class TransitLine implements Serializable {
 
   /** The type of vehicle used on this transit line. */
   public Vehicle vehicle;
+
+  public String toString() {
+    return String.format("%s \"%s\"", shortName, name);
+  }
 }

--- a/src/main/java/com/google/maps/model/Vehicle.java
+++ b/src/main/java/com/google/maps/model/Vehicle.java
@@ -42,4 +42,8 @@ public class Vehicle implements Serializable {
 
   /** The URL for an icon based on the local transport signage. */
   public String localIcon;
+
+  public String toString() {
+    return String.format("%s (%s)", name, type);
+  }
 }

--- a/src/main/java/com/google/maps/model/WifiAccessPoint.java
+++ b/src/main/java/com/google/maps/model/WifiAccessPoint.java
@@ -61,6 +61,27 @@ public class WifiAccessPoint implements Serializable {
   /** The current signal to noise ratio measured in dB. */
   public Integer signalToNoiseRatio = null;
 
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[WifiAccessPoint:");
+    if (macAddress != null) {
+      sb.append(" macAddress=").append(macAddress);
+    }
+    if (signalStrength != null) {
+      sb.append(" signalStrength=").append(signalStrength);
+    }
+    if (age != null) {
+      sb.append(" age=").append(age);
+    }
+    if (channel != null) {
+      sb.append(" channel=").append(channel);
+    }
+    if (signalToNoiseRatio != null) {
+      sb.append(" signalToNoiseRatio=").append(signalToNoiseRatio);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
   public static class WifiAccessPointBuilder {
     private String _macAddress = null;
     private Integer _signalStrength = null;

--- a/src/test/java/com/google/maps/DirectionsApiTest.java
+++ b/src/test/java/com/google/maps/DirectionsApiTest.java
@@ -33,6 +33,7 @@ import com.google.maps.model.TransitRoutingPreference;
 import com.google.maps.model.TravelMode;
 import com.google.maps.model.Unit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -62,11 +63,14 @@ public class DirectionsApiTest {
           DirectionsApi.getDirections(sc.context, "Sydney, AU", "Melbourne, AU").await();
 
       assertNotNull(result);
+      assertNotNull(result.toString(), "result.toString() succeeded");
       assertNotNull(result.geocodedWaypoints);
+      assertNotNull(Arrays.toString(result.geocodedWaypoints));
       assertEquals(2, result.geocodedWaypoints.length);
       assertEquals("ChIJP3Sa8ziYEmsRUKgyFmh9AQM", result.geocodedWaypoints[0].placeId);
       assertEquals("ChIJ90260rVG1moRkM2MIXVWBAQ", result.geocodedWaypoints[1].placeId);
       assertNotNull(result.routes);
+      assertNotNull(Arrays.toString(result.routes));
       assertEquals(1, result.routes.length);
       assertNotNull(result.routes[0]);
       assertEquals("M31 and National Highway M31", result.routes[0].summary);
@@ -357,6 +361,7 @@ public class DirectionsApiTest {
               .destination("182 Church St, Parramatta NSW 2150, Australia")
               .await();
 
+      assertNotNull(result.toString());
       assertNotNull(result.routes);
       assertNotNull(result.routes[0]);
 
@@ -411,6 +416,7 @@ public class DirectionsApiTest {
               .mode(TravelMode.DRIVING)
               .await();
 
+      assertNotNull(result.toString());
       assertNotNull(result.geocodedWaypoints);
       assertEquals(2, result.geocodedWaypoints.length);
       assertEquals(GeocodedWaypointStatus.OK, result.geocodedWaypoints[0].geocoderStatus);

--- a/src/test/java/com/google/maps/DistanceMatrixApiTest.java
+++ b/src/test/java/com/google/maps/DistanceMatrixApiTest.java
@@ -17,6 +17,7 @@ package com.google.maps;
 
 import static com.google.maps.TestUtils.retrieveBody;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.maps.DirectionsApi.RouteRestriction;
 import com.google.maps.model.DistanceMatrix;
@@ -25,6 +26,7 @@ import com.google.maps.model.LatLng;
 import com.google.maps.model.TrafficModel;
 import com.google.maps.model.TravelMode;
 import com.google.maps.model.Unit;
+import java.util.Arrays;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -73,6 +75,9 @@ public class DistanceMatrixApiTest {
           };
       DistanceMatrix matrix =
           DistanceMatrixApi.getDistanceMatrix(sc.context, origins, destinations).await();
+
+      assertNotNull(matrix.toString());
+      assertNotNull(Arrays.toString(matrix.rows));
 
       // Rows length will match the number of origin elements, regardless of whether they're
       // routable.

--- a/src/test/java/com/google/maps/ElevationApiTest.java
+++ b/src/test/java/com/google/maps/ElevationApiTest.java
@@ -113,6 +113,7 @@ public class ElevationApiTest {
       ElevationResult result = ElevationApi.getByPoint(sc.context, SYDNEY).await();
 
       assertNotNull(result);
+      assertNotNull(result.toString());
       assertEquals(SYDNEY_POINT_ELEVATION, result.elevation, EPSILON);
 
       sc.assertParamValue(SYDNEY.toUrlValue(), "locations");

--- a/src/test/java/com/google/maps/GeocodingApiTest.java
+++ b/src/test/java/com/google/maps/GeocodingApiTest.java
@@ -30,6 +30,7 @@ import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.LocationType;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,11 +61,13 @@ public class GeocodingApiTest {
   public void testGeocodeLibraryType() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext(geocodeLibraryType)) {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).address("80 FR").await();
+
       assertEquals(1, results.length);
       assertEquals(3, results[0].types.length);
       assertEquals(AddressType.ESTABLISHMENT, results[0].types[0]);
       assertEquals(AddressType.LIBRARY, results[0].types[1]);
       assertEquals(AddressType.POINT_OF_INTEREST, results[0].types[2]);
+      assertNotNull(Arrays.toString(results));
     }
   }
 
@@ -73,6 +76,7 @@ public class GeocodingApiTest {
     try (LocalTestServerContext sc = new LocalTestServerContext(simpleGeocodeResponse)) {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).address("Sydney").await();
       checkSydneyResult(results);
+      assertNotNull(Arrays.toString(results));
 
       sc.assertParamValue("Sydney", "address");
     }
@@ -236,6 +240,7 @@ public class GeocodingApiTest {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).address(address).await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals(
           "Google Bldg 41, 1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
           results[0].formattedAddress);
@@ -323,6 +328,8 @@ public class GeocodingApiTest {
               .bounds(new LatLng(34.172684, -118.604794), new LatLng(34.236144, -118.500938))
               .await();
 
+      assertNotNull(Arrays.toString(results));
+
       assertEquals("Winnetka, Los Angeles, CA, USA", results[0].formattedAddress);
       assertEquals("ChIJ0fd4S_KbwoAR2hRDrsr3HmQ", results[0].placeId);
 
@@ -402,6 +409,8 @@ public class GeocodingApiTest {
                 + "}\n")) {
       GeocodingResult[] results =
           GeocodingApi.newRequest(sc.context).address("Toledo").region("es").await();
+
+      assertNotNull(Arrays.toString(results));
 
       assertNotNull(results);
       assertEquals("Toledo, Spain", results[0].formattedAddress);
@@ -488,6 +497,8 @@ public class GeocodingApiTest {
               .components(ComponentFilter.country("ES"))
               .await();
 
+      assertNotNull(Arrays.toString(results));
+
       assertEquals("Santa Cruz de Tenerife, Spain", results[0].formattedAddress);
       assertEquals("ChIJcUElzOzMQQwRLuV30nMUEUM", results[0].placeId);
 
@@ -571,6 +582,8 @@ public class GeocodingApiTest {
               .address("Torun")
               .components(administrativeArea("TX"), country("US"))
               .await();
+
+      assertNotNull(Arrays.toString(results));
 
       assertEquals("Texas, USA", results[0].formattedAddress);
       assertEquals(true, results[0].partialMatch);
@@ -660,6 +673,7 @@ public class GeocodingApiTest {
               .await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals("Annankatu, 00101 Helsinki, Finland", results[0].formattedAddress);
       assertEquals("EiBBbm5hbmthdHUsIDAwMTAxIEhlbHNpbmtpLCBTdW9taQ", results[0].placeId);
 
@@ -680,6 +694,7 @@ public class GeocodingApiTest {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).latlng(latlng).await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals("277 Bedford Ave, Brooklyn, NY 11211, USA", results[0].formattedAddress);
       assertEquals("277", results[0].addressComponents[0].longName);
       assertEquals("277", results[0].addressComponents[0].shortName);
@@ -779,6 +794,7 @@ public class GeocodingApiTest {
               .await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals("277 Bedford Ave, Brooklyn, NY 11211, USA", results[0].formattedAddress);
       assertEquals(LocationType.ROOFTOP, results[0].geometry.locationType);
       assertEquals("ChIJd8BlQ2BZwokRAFUEcm_qrcA", results[0].placeId);
@@ -898,6 +914,7 @@ public class GeocodingApiTest {
               .custom("new_forward_geocoder", "true")
               .await();
 
+      assertNotNull(Arrays.toString(results));
       assertEquals(
           "Google Bldg 41, 1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
           results[0].formattedAddress);
@@ -916,6 +933,7 @@ public class GeocodingApiTest {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).latlng(location).await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals(
           "Japan, 〒603-8361 Kyōto-fu, Kyōto-shi, Kita-ku, Kinkakujichō, １ 北山鹿苑寺金閣寺",
           results[0].formattedAddress);
@@ -1009,6 +1027,7 @@ public class GeocodingApiTest {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).address(address).await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals(AddressType.ESTABLISHMENT, results[0].types[0]);
       assertEquals(AddressType.FOOD, results[0].types[1]);
       assertEquals(AddressType.GROCERY_OR_SUPERMARKET, results[0].types[2]);
@@ -1093,6 +1112,7 @@ public class GeocodingApiTest {
       GeocodingResult[] results = GeocodingApi.newRequest(sc.context).address(address).await();
 
       assertNotNull(results);
+      assertNotNull(Arrays.toString(results));
       assertEquals(AddressType.ESTABLISHMENT, results[0].types[0]);
       assertEquals(AddressType.PLACE_OF_WORSHIP, results[0].types[1]);
       assertEquals(AddressType.POINT_OF_INTEREST, results[0].types[2]);

--- a/src/test/java/com/google/maps/GeolocationApiTest.java
+++ b/src/test/java/com/google/maps/GeolocationApiTest.java
@@ -88,6 +88,8 @@ public class GeolocationApiTest {
               .CreatePayload()
               .await();
 
+      assertNotNull(result.toString());
+
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
       assertEquals(310, body.get("homeMobileCountryCode"));
@@ -116,6 +118,8 @@ public class GeolocationApiTest {
                       .createWifiAccessPoint())
               .CreatePayload()
               .await();
+
+      assertNotNull(result.toString());
 
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
@@ -148,6 +152,8 @@ public class GeolocationApiTest {
                       .createWifiAccessPoint())
               .CreatePayload()
               .await();
+
+      assertNotNull(result.toString());
 
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
@@ -185,6 +191,8 @@ public class GeolocationApiTest {
               .WifiAccessPoints(wifiAccessPoints)
               .CreatePayload()
               .await();
+
+      assertNotNull(result.toString());
 
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
@@ -228,6 +236,8 @@ public class GeolocationApiTest {
               .CreatePayload()
               .await();
 
+      assertNotNull(result.toString());
+
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
       assertEquals(310, body.get("homeMobileCountryCode"));
@@ -269,6 +279,8 @@ public class GeolocationApiTest {
               .CreatePayload()
               .await();
 
+      assertNotNull(result.toString());
+
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
       JSONObject cellTower = body.getJSONArray("cellTowers").getJSONObject(0);
@@ -299,6 +311,7 @@ public class GeolocationApiTest {
               .createGeolocationPayload();
 
       GeolocationResult result = GeolocationApi.geolocate(sc.context, payload).await();
+      assertNotNull(result.toString());
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
       JSONObject cellTower = body.getJSONArray("cellTowers").getJSONObject(0);
@@ -335,6 +348,8 @@ public class GeolocationApiTest {
               .CreatePayload()
               .await();
 
+      assertNotNull(result.toString());
+
       JSONObject body = sc.requestBody();
       assertEquals(false, body.get("considerIp"));
       assertEquals(310, body.get("homeMobileCountryCode"));
@@ -363,6 +378,7 @@ public class GeolocationApiTest {
 
       GeolocationResult result = GeolocationApi.geolocate(sc.context, payload).await();
       assertNotNull(result);
+      assertNotNull(result.toString());
       assertNotNull(result.location);
     }
   }
@@ -373,6 +389,7 @@ public class GeolocationApiTest {
       GeolocationResult result = GeolocationApi.newRequest(sc.context).CreatePayload().await();
 
       assertNotNull(result);
+      assertNotNull(result.toString());
       assertNotNull(result.location);
     }
   }

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -138,6 +138,7 @@ public class PlacesApiTest {
           PlacesApi.placeAutocomplete(sc.context, "1", session).await();
 
       assertNotNull(predictions);
+      assertNotNull(Arrays.toString(predictions));
       assertEquals(1, predictions.length);
       final AutocompletePrediction prediction = predictions[0];
       assertNotNull(prediction);
@@ -169,6 +170,7 @@ public class PlacesApiTest {
       sc.assertParamValue("place_id,name,types", "fields");
 
       assertNotNull(placeDetails);
+      assertNotNull(placeDetails.toString());
 
       // Address
       assertNotNull(placeDetails.addressComponents);
@@ -341,6 +343,7 @@ public class PlacesApiTest {
       PlaceDetails placeDetails =
           PlacesApi.placeDetails(sc.context, PERMANENTLY_CLOSED_PLACE_ID).await();
       assertNotNull(placeDetails);
+      assertNotNull(placeDetails.toString());
       assertTrue(placeDetails.permanentlyClosed);
     }
   }
@@ -350,6 +353,7 @@ public class PlacesApiTest {
     try (LocalTestServerContext sc = new LocalTestServerContext(quayResponseBody)) {
       PlaceDetails placeDetails = PlacesApi.placeDetails(sc.context, QUAY_PLACE_ID).await();
       assertNotNull(placeDetails);
+      assertNotNull(placeDetails.toString());
       assertNotNull(placeDetails.priceLevel);
       assertEquals(PriceLevel.VERY_EXPENSIVE, placeDetails.priceLevel);
       assertNotNull(placeDetails.photos);
@@ -392,6 +396,7 @@ public class PlacesApiTest {
 
       assertNotNull(predictions);
       assertEquals(predictions.length, 5);
+      assertNotNull(Arrays.toString(predictions));
 
       AutocompletePrediction prediction = predictions[0];
       assertNotNull(prediction);
@@ -419,6 +424,7 @@ public class PlacesApiTest {
 
       assertNotNull(predictions);
       assertEquals(predictions.length, 1);
+      assertNotNull(Arrays.toString(predictions));
 
       AutocompletePrediction prediction = predictions[0];
       assertNotNull(prediction);
@@ -484,6 +490,7 @@ public class PlacesApiTest {
       assertNotNull(results);
       assertNotNull(results.results);
       assertEquals(1, results.results.length);
+      assertNotNull(results.toString());
 
       PlacesSearchResult result = results.results[0];
       assertNotNull(result.formattedAddress);
@@ -532,6 +539,7 @@ public class PlacesApiTest {
     try (LocalTestServerContext sc = new LocalTestServerContext(textSearchPizzaInNYCbody)) {
       PlacesSearchResponse results =
           PlacesApi.textSearchQuery(sc.context, "Pizza in New York").await();
+      assertNotNull(results.toString());
       assertNotNull(results.nextPageToken);
       assertEquals(
           "CuQB1wAAANI17eHXt1HpqbLjkj7T5Ti69DEAClo02Qampg7Q6W_O_krFbge7hnTtDR7oVF3asex"
@@ -692,6 +700,7 @@ public class PlacesApiTest {
 
       sc.assertParamValue("Google Sydney", "query");
 
+      assertNotNull(response.toString());
       assertEquals(1, response.results.length);
       PlacesSearchResult result = response.results[0];
       assertEquals("5, 48 Pirrama Rd, Pyrmont NSW 2009, Australia", result.formattedAddress);
@@ -706,6 +715,7 @@ public class PlacesApiTest {
 
       sc.assertParamValue("ChIJN1t_tDeuEmsRUsoyG83frY4", "placeid");
 
+      assertNotNull(placeDetails.toString());
       assertEquals(10, placeDetails.photos.length);
       assertEquals(
           "CmRaAAAA-N3w5YTMXWautuDW7IZgX9knz_2fNyyUpCWpvYdVEVb8RurBiisMKvr7AFxMW8dsu2yakYoqjW-IYSFk2cylXVM_c50cCxfm7MlgjPErFxumlcW1bLNOe--SwLYmWlvkEhDxjz75xRqim-CkVlwFyp7sGhTs1fE02MZ6GQcc-TugrepSaeWapA",
@@ -723,6 +733,7 @@ public class PlacesApiTest {
 
       sc.assertParamValue("Pizza in New York", "query");
 
+      assertNotNull(response.toString());
       assertEquals(20, response.results.length);
       assertEquals(
           "CvQB6AAAAPQLwX6KjvGbOw81Y7aYVhXRlHR8M60aCRXFDM9eyflac4BjE5MaNxTj_1T429x3H2kzBd-ztTFXCSu1CPh3kY44Gu0gmL-xfnArnPE9-BgfqXTpgzGPZNeCltB7m341y4LnU-NE2omFPoDWIrOPIyHnyi05Qol9eP2wKW7XPUhMlHvyl9MeVgZ8COBZKvCdENHbhBD1MN1lWlada6A9GPFj06cCp1aqRGW6v98-IHcIcM9RcfMcS4dLAFm6TsgLq4tpeU6E1kSzhrvDiLMBXdJYFlI0qJmytd2wS3vD0t3zKgU6Im_mY-IJL7AwAqhugBIQ8k0X_n6TnacL9BExELBaixoUo8nPOwWm0Nx02haufF2dY0VL-tg",
@@ -739,6 +750,7 @@ public class PlacesApiTest {
       sc.assertParamValue("ChIJ442GNENu5kcRGYUrvgqHw88", "placeid");
       sc.assertParamValue("fr", "language");
 
+      assertNotNull(details.toString());
       assertEquals("ChIJ442GNENu5kcRGYUrvgqHw88", details.placeId);
       assertEquals(
           "35 Rue du Chevalier de la Barre, 75018 Paris, France", details.formattedAddress);
@@ -876,6 +888,7 @@ public class PlacesApiTest {
       sc.assertParamValue("(regions)", "types");
       sc.assertParamValue(session.toUrlValue(), "sessiontoken");
 
+      assertNotNull(Arrays.toString(predictions));
       assertEquals(5, predictions.length);
       for (AutocompletePrediction prediction : predictions) {
         for (int j = 0; j < prediction.types.length; j++) {

--- a/src/test/java/com/google/maps/RoadsApiIntegrationTest.java
+++ b/src/test/java/com/google/maps/RoadsApiIntegrationTest.java
@@ -25,6 +25,7 @@ import com.google.maps.model.LatLng;
 import com.google.maps.model.SnappedPoint;
 import com.google.maps.model.SnappedSpeedLimitResponse;
 import com.google.maps.model.SpeedLimit;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -62,6 +63,7 @@ public class RoadsApiIntegrationTest {
           };
       SnappedPoint[] points = RoadsApi.snapToRoads(sc.context, false, path).await();
 
+      assertNotNull(Arrays.toString(points));
       sc.assertParamValue(join('|', path), "path");
       sc.assertParamValue("false", "interpolate");
       assertEquals(7, points.length);
@@ -86,6 +88,7 @@ public class RoadsApiIntegrationTest {
           };
       SpeedLimit[] speeds = RoadsApi.speedLimits(sc.context, path).await();
 
+      assertNotNull(Arrays.toString(speeds));
       assertEquals("/v1/speedLimits", sc.path());
       sc.assertParamValue(join('|', path), "path");
       assertEquals(7, speeds.length);
@@ -112,6 +115,7 @@ public class RoadsApiIntegrationTest {
           };
       SpeedLimit[] speeds = RoadsApi.speedLimits(sc.context, path).await();
 
+      assertNotNull(Arrays.toString(speeds));
       assertEquals("/v1/speedLimits", sc.path());
       sc.assertParamValue(join('|', path), "path");
       assertEquals(7, speeds.length);
@@ -134,6 +138,7 @@ public class RoadsApiIntegrationTest {
           };
       SpeedLimit[] speeds = RoadsApi.speedLimits(sc.context, placeIds).await();
 
+      assertNotNull(Arrays.toString(speeds));
       assertEquals("/v1/speedLimits", sc.path());
       assertEquals(3, speeds.length);
       assertEquals("ChIJc0BrC2EE9YgR71DvaFzNgrA", speeds[2].placeId);
@@ -159,6 +164,7 @@ public class RoadsApiIntegrationTest {
           };
       SnappedSpeedLimitResponse response = RoadsApi.snappedSpeedLimits(sc.context, path).await();
 
+      assertNotNull(response.toString());
       assertEquals("/v1/speedLimits", sc.path());
       sc.assertParamValue(join('|', path), "path");
       assertEquals(path.length, response.snappedPoints.length);
@@ -181,6 +187,7 @@ public class RoadsApiIntegrationTest {
           };
       SnappedPoint[] points = RoadsApi.nearestRoads(sc.context, path).await();
 
+      assertNotNull(Arrays.toString(points));
       assertEquals("/v1/nearestRoads", sc.path());
       sc.assertParamValue(join('|', path), "points");
       assertEquals(13, points.length);


### PR DESCRIPTION
Closes #450.

This PR adds value-based custom `toString()` methods to all the `model` objects. This should be useful for debugging, including incorporation into log messages, and interactive use inside scripting environments like Matlab and Jython.

Value-based toString()s are appropriate here because the model objects are value objects; their object identity doesn't matter as much as their contents, so the default `<ClassName>@<ObjectId>` toString() output is not very useful.

This PR affects user-visible behavior for existing classes, so you might want to sit on it a few days to allow other users to comment.

If this approach looks good to you, I'll add some tests.