### PR TITLE
PlaceDetails: make types an AddressType[] instead of String[]

### DIFF
--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -186,7 +186,7 @@ public class PlaceDetails implements Serializable {
   public Review[] reviews;
 
   /** Feature types describing the given result. */
-  public String[] types;
+  public AddressType[] types;
 
   /**
    * The URL of the official Google page for this place. This will be the establishment's Google+

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -28,6 +28,7 @@ import com.google.maps.FindPlaceFromTextRequest.LocationBiasPoint;
 import com.google.maps.FindPlaceFromTextRequest.LocationBiasRectangular;
 import com.google.maps.PlaceAutocompleteRequest.SessionToken;
 import com.google.maps.model.AddressComponentType;
+import com.google.maps.model.AddressType;
 import com.google.maps.model.AutocompletePrediction;
 import com.google.maps.model.AutocompletePrediction.MatchedSubstring;
 import com.google.maps.model.AutocompleteStructuredFormatting;
@@ -325,7 +326,7 @@ public class PlacesApiTest {
       assertNotNull(placeDetails.scope);
       assertEquals(placeDetails.scope, PlaceIdScope.GOOGLE);
       assertNotNull(placeDetails.types);
-      assertEquals(placeDetails.types[0], "establishment");
+      assertEquals(placeDetails.types[0], AddressType.ESTABLISHMENT);
       assertEquals(placeDetails.rating, 4.4, 0.1);
 
       // Permanently closed:


### PR DESCRIPTION
Fixes #434.

The Place Details API doc says the values in `types` are valid address types, so we can, and probably should, represent them as AddressTypes.