### PR TITLE
Deprecate NearbySearchRequest.type(PlaceType...)

### DIFF
--- a/src/main/java/com/google/maps/NearbySearchRequest.java
+++ b/src/main/java/com/google/maps/NearbySearchRequest.java
@@ -162,9 +162,11 @@ public class NearbySearchRequest
    * Restricts the results to places matching the specified type. Provides support for multiple
    * types.
    *
+   * @deprecated Multiple search types are ignored by the Places API.
    * @param types The {@link PlaceType}s to restrict results to.
    * @return Returns this {@code NearbyApiRequest} for call chaining.
    */
+  @Deprecated
   public NearbySearchRequest type(PlaceType... types) {
     return param("type", join('|', types));
   }


### PR DESCRIPTION
Fixes #430.

Per the [Place Search Request doco](https://developers.google.com/places/web-service/search#PlaceSearchRequests), `type` arguments after the first are silently ignored.