### PR TITLE
Have OkHttpRequestHandler evict connectionPool on shutdown

### DIFF
--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -92,6 +92,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
 
   public void shutdown() {
     executorService.shutdown();
+    client.connectionPool().evictAll();
   }
 
   /** Builder strategy for constructing an {@code OkHTTPRequestHandler}. */


### PR DESCRIPTION
This is a minor optimization to support clients that are "doing the wrong thing" and creating many GeoApiContext objects. It somewhat reduces thread and memory pressure in that situation, and makes applications easier to monitor in tools like VisualVM.

Without this patch, in my testing, OkHttpWorker threads accumulate up to about 800 threads before leveling off, with several threads appearing per new GeoApiContext object. With this patch, the growth is slower, and steady state levels off at about 300 threads.

This is not a critical fix; just a nicety for some users.

Follows up discussion in #261.