### PR TITLE
Add Plus Code support to GeocodingResult and PlaceDetails

### DIFF
--- a/src/main/java/com/google/maps/model/GeocodingResult.java
+++ b/src/main/java/com/google/maps/model/GeocodingResult.java
@@ -71,4 +71,7 @@ public class GeocodingResult implements Serializable {
 
   /** A unique identifier for this place. */
   public String placeId;
+
+  /** The Plus Code identifier for this place. */
+  public PlusCode plusCode;
 }

--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -70,6 +70,9 @@ public class PlaceDetails implements Serializable {
   /** The scope of the placeId. */
   public PlaceIdScope scope;
 
+  /** The Plus Code location identifier for this place. */
+  public PlusCode plusCode;
+
   /** Whether the place has permanently closed. */
   public boolean permanentlyClosed;
 

--- a/src/main/java/com/google/maps/model/PlusCode.java
+++ b/src/main/java/com/google/maps/model/PlusCode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.google.maps.model;
+
+/** A Plus Code encoded location reference. */
+public class PlusCode {
+  /** The global Plus Code identifier. */
+  public String globalCode;
+
+  /** The compound Plus Code identifier. May be null for locations in remote areas. */
+  public String compoundCode;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[PlusCode: ");
+    sb.append(globalCode);
+    if (compoundCode != null) {
+      sb.append(", compoundCode=").append(compoundCode);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/src/test/resources/com/google/maps/PlaceDetailsLookupGoogleSydneyResponse.json
+++ b/src/test/resources/com/google/maps/PlaceDetailsLookupGoogleSydneyResponse.json
@@ -250,6 +250,10 @@
       }
     ],
     "place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4",
+    "plus_code": {
+      "compound_code": "45MW+98 Pyrmont, New South Wales, Australia",
+      "global_code": "4RRH45MW+98"
+    },
     "rating": 4.4,
     "reference": "CmRSAAAAGQJ6PTZr7ufM6fQmQKWECuhtbE5MxVWAVx1Potb6nllk7YrtrHYdMRttPrQfxHdAkFOaiZikxMustzx-R29lup1t8EZ5QhipfhEi9hJaM5AdNTBvo1Nrv7v03MtsEVj6EhDGokaqFIy6yIRgB6b_iKplGhQL3qLuxxusScGvkWpJCSJFafCbog",
     "reviews": [


### PR DESCRIPTION
Fixes #458.

I've added test data for the PlaceDetails support, but not for the GeocodingResult, because I'm not able to see `plus_code` in my Geocoding queries yet, probably due to a staged rollout of the Plus Code feature. This PR adds forward-compatible support for clients who can see it, though.