### PR TITLE
Add okHttpClientBuilder() for customizing the OkHttpClient

### DIFF
--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -154,6 +154,18 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
           });
     }
 
+    /**
+     * Gets a reference to the OkHttpClient.Builder used to build the OkHttpRequestHandler's
+     * internal OkHttpClient. This allows you to fully customize the OkHttpClient that the resulting
+     * OkHttpRequestHandler will make HTTP requests through.
+     *
+     * @return OkHttpClient.Builder that will produce the OkHttpClient used by the
+     *     OkHttpRequestHandler built by this.
+     */
+    public OkHttpClient.Builder okHttpClientBuilder() {
+      return builder;
+    }
+
     @Override
     public RequestHandler build() {
       OkHttpClient client = builder.build();


### PR DESCRIPTION
Here's one approach for satisfying #427.

This exposes the OkHttpRequestHandler.Builder's nested OkHttpClient.Builder for direct customization by the caller.

I chose to do it this way, instead of defining a `okHttpClientBuilder(OkHttpClient.Builder newBuilder)` setter because the setter would interact with `readTimeout(...)`, `writeTimeout(...)`, `proxyAuthentication(...)`, and other methods which delegate to the underlying OkHttpClient.Builder, and you'd have to be careful about the order you called them in then.

This would be for advanced users, and would allow them to do things like set additional timeouts, configure proxies, and add interceptors for logging. The downside is that it would be possible to configure some of the settings in ways that break the service (e.g. by fiddling with the accepted protocols list or DNS settings, adding bogus interceptors, and so on). I think that's a reasonable risk, though: this library seems aimed at proficient developers, and I think it's clear that these are advanced lower-level settings.