### PR TITLE
Change *RequestHandler Builder signatures to do chainable calls

### DIFF
--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -102,37 +102,37 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
   public static class Builder implements GeoApiContext.RequestHandler.Builder {
 
     @Override
-    public void connectTimeout(long timeout, TimeUnit unit) {
+    public Builder connectTimeout(long timeout, TimeUnit unit) {
       // TODO: Investigate if GAE URL Fetch Service supports setting connection timeout
       throw new RuntimeException("connectTimeout not implemented for Google App Engine");
     }
 
     @Override
-    public void readTimeout(long timeout, TimeUnit unit) {
+    public Builder readTimeout(long timeout, TimeUnit unit) {
       // TODO: Investigate if GAE URL Fetch Service supports setting read timeout
       throw new RuntimeException("readTimeout not implemented for Google App Engine");
     }
 
     @Override
-    public void writeTimeout(long timeout, TimeUnit unit) {
+    public Builder writeTimeout(long timeout, TimeUnit unit) {
       // TODO: Investigate if GAE URL Fetch Service supports setting write timeout
       throw new RuntimeException("writeTimeout not implemented for Google App Engine");
     }
 
     @Override
-    public void queriesPerSecond(int maxQps) {
+    public Builder queriesPerSecond(int maxQps) {
       // TODO: Investigate if GAE URL Fetch Service supports setting qps
       throw new RuntimeException("queriesPerSecond not implemented for Google App Engine");
     }
 
     @Override
-    public void proxy(Proxy proxy) {
+    public Builder proxy(Proxy proxy) {
       // TODO: Investigate if GAE URL Fetch Service supports setting proxy
       throw new RuntimeException("setProxy not implemented for Google App Engine");
     }
 
     @Override
-    public void proxyAuthentication(String proxyUserName, String proxyUserPassword) {
+    public Builder proxyAuthentication(String proxyUserName, String proxyUserPassword) {
       // TODO: Investigate if GAE URL Fetch Service supports setting proxy authentication
       throw new RuntimeException("setProxyAuthentication not implemented for Google App Engine");
     }

--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -120,17 +120,17 @@ public class GeoApiContext {
     /** Builder pattern for {@code GeoApiContext.RequestHandler}. */
     interface Builder {
 
-      void connectTimeout(long timeout, TimeUnit unit);
+      Builder connectTimeout(long timeout, TimeUnit unit);
 
-      void readTimeout(long timeout, TimeUnit unit);
+      Builder readTimeout(long timeout, TimeUnit unit);
 
-      void writeTimeout(long timeout, TimeUnit unit);
+      Builder writeTimeout(long timeout, TimeUnit unit);
 
-      void queriesPerSecond(int maxQps);
+      Builder queriesPerSecond(int maxQps);
 
-      void proxy(Proxy proxy);
+      Builder proxy(Proxy proxy);
 
-      void proxyAuthentication(String proxyUserName, String proxyUserPassword);
+      Builder proxyAuthentication(String proxyUserName, String proxyUserPassword);
 
       RequestHandler build();
     }

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -109,34 +109,39 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
     }
 
     @Override
-    public void connectTimeout(long timeout, TimeUnit unit) {
+    public Builder connectTimeout(long timeout, TimeUnit unit) {
       builder.connectTimeout(timeout, unit);
+      return this;
     }
 
     @Override
-    public void readTimeout(long timeout, TimeUnit unit) {
+    public Builder readTimeout(long timeout, TimeUnit unit) {
       builder.readTimeout(timeout, unit);
+      return this;
     }
 
     @Override
-    public void writeTimeout(long timeout, TimeUnit unit) {
+    public Builder writeTimeout(long timeout, TimeUnit unit) {
       builder.writeTimeout(timeout, unit);
+      return this;
     }
 
     @Override
-    public void queriesPerSecond(int maxQps) {
+    public Builder queriesPerSecond(int maxQps) {
       dispatcher.setMaxRequests(maxQps);
       dispatcher.setMaxRequestsPerHost(maxQps);
       rateLimitExecutorService.setQueriesPerSecond(maxQps);
+      return this;
     }
 
     @Override
-    public void proxy(Proxy proxy) {
+    public Builder proxy(Proxy proxy) {
       builder.proxy(proxy);
+      return this;
     }
 
     @Override
-    public void proxyAuthentication(String proxyUserName, String proxyUserPassword) {
+    public Builder proxyAuthentication(String proxyUserName, String proxyUserPassword) {
       final String userName = proxyUserName;
       final String password = proxyUserPassword;
 
@@ -152,6 +157,7 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
                   .build();
             }
           });
+      return this;
     }
 
     /**


### PR DESCRIPTION
Most Builder Pattern objects have their setters return `this` so calls are chainable. GeoApiContext.RequestHandler.Builder and its concrete implementations do not do this; they return `void` instead.

This seems like just an oversight to me; I don't see a technical reason for them not to be chainable.

This PR changes GeoApiContext.RequestHandler.Builder and its concrete subclasses to return `this` from its setter methods, so calls on them are chainable.