### PR TITLE
Replace "baseUrlForTesting()" with usage-neutral "baseUrlOverride()"

### DIFF
--- a/src/main/java/com/google/maps/GeoApiContext.java
+++ b/src/main/java/com/google/maps/GeoApiContext.java
@@ -339,14 +339,28 @@ public class GeoApiContext {
     }
 
     /**
-     * Overrides the base URL of the API endpoint. Useful only for testing.
+     * Overrides the base URL of the API endpoint. Useful for testing or certain international
+     * usage scenarios.
      *
      * @param baseUrl The URL to use, without a trailing slash, e.g. https://maps.googleapis.com
      * @return Returns this builder for call chaining.
      */
-    Builder baseUrlForTesting(String baseUrl) {
+    Builder baseUrlOverride(String baseUrl) {
       baseUrlOverride = baseUrl;
       return this;
+    }
+
+    /**
+     * Older name for {@link #baseUrlOverride(String)}. This was used back when testing was the
+     * only use case foreseen for this.
+     *
+     * @deprecated Use baseUrlOverride(String) instead.
+     * @param baseUrl The URL to use, without a trailing slash, e.g. https://maps.googleapis.com
+     * @return Returns this builder for call chaining.
+     */
+    @Deprecated
+    Builder baseUrlForTesting(String baseUrl) {
+      return baseUrlOverride(baseUrl);
     }
 
     /**

--- a/src/test/java/com/google/maps/LocalTestServerContext.java
+++ b/src/test/java/com/google/maps/LocalTestServerContext.java
@@ -54,7 +54,7 @@ public class LocalTestServerContext implements AutoCloseable {
     this.context =
         new GeoApiContext.Builder()
             .apiKey("AIzaFakeKey")
-            .baseUrlForTesting("http://127.0.0.1:" + server.getPort())
+            .baseUrlOverride("http://127.0.0.1:" + server.getPort())
             .build();
   }
 
@@ -69,7 +69,7 @@ public class LocalTestServerContext implements AutoCloseable {
     this.context =
         new GeoApiContext.Builder()
             .apiKey("AIzaFakeKey")
-            .baseUrlForTesting("http://127.0.0.1:" + server.getPort())
+            .baseUrlOverride("http://127.0.0.1:" + server.getPort())
             .build();
   }
 


### PR DESCRIPTION
Fixes #435.

The name `baseUrlForTesting` implies a certain use case, but the action is really a general override of the base URL. Turns out it's useful in other scenarios, such as querying Google Maps from China, as stated in #435.

This PR replaces `baseUrlForTesting(...)` with a new usage-neutral-terminology `baseUrlOverride(...)` that describes what it does, but not why. The old `baseUrlForTesting(...)` is left around in a `@Deprecated` state for now.