### PR TITLE
Supply -html4 to javadoc with JDK 10 and later

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ tasks.withType(Test) {
 
 javadoc {
     exclude '**/internal/**'
+    def currentJavaVersion = org.gradle.api.JavaVersion.current()
+    if (currentJavaVersion.compareTo(org.gradle.api.JavaVersion.VERSION_1_9) > 0) {
+      options.addBooleanOption('html4', true)
+    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Fixes #467

This PR supplies an explicit `-html4` to `javadoc` when running under JDK 10 and later. Otherwise, they complain about the Javadoc HTML version not being explicitly specified.