### PR TITLE
Update gradle dependency keywords

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'jacoco'
@@ -45,17 +46,17 @@ artifacts {
 
 dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.64'
-    compile 'com.google.code.gson:gson:2.8.5'
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
-    compile 'joda-time:joda-time:2.10'
-    compile 'org.slf4j:slf4j-api:1.7.25'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.19.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    testCompile 'org.apache.httpcomponents:httpclient:4.5.5'
-    testCompile 'org.slf4j:slf4j-simple:1.7.25'
-    testCompile 'commons-lang:commons-lang:2.6'
-    testCompile 'org.json:json:20180130'
+    api 'com.squareup.okhttp3:okhttp:3.10.0'
+    api 'joda-time:joda-time:2.10'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'org.slf4j:slf4j-api:1.7.25'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.19.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.5'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.25'
+    testImplementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'org.json:json:20180130'
 }
 
 task updateVersion(type: Copy) {


### PR DESCRIPTION
Per the [Gradle 4.8.1 documentation](https://docs.gradle.org/4.8.1/userguide/java_plugin.html), the 'compile' and 'testCompile' keywords are deprecated. 

This PR updates `build.gradle` to use the current non-deprecated alternatives.

This might be a breaking change for client code that is building with Gradle or Maven and relying on google-maps-services-java to provide transitive dependencies for these libraries. I think that's acceptable, though, because they "shouldn't be" doing that, and the fix is easy: just add the dependencies to their own `build.gradle` file.