### PR TITLE
PlaceDetails: add adr_address support

### DIFF
--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -35,6 +35,9 @@ public class PlaceDetails implements Serializable {
   /** A list of separate address components that comprise the address of this place. */
   public AddressComponent[] addressComponents;
 
+  /** A representation of the place's address in the adr microformat. */
+  public String adrAddress;
+
   /** The human-readable address of this place. */
   public String formattedAddress;
 


### PR DESCRIPTION
Fixes #479.

I did not include `adrAddress` in the toString output because it's pretty long and noisy IMHO, repeating other information already in toString().