### PR TITLE
Fixed typo in field

### DIFF
--- a/src/main/java/com/google/maps/PlaceDetailsRequest.java
+++ b/src/main/java/com/google/maps/PlaceDetailsRequest.java
@@ -134,7 +134,7 @@ public class PlaceDetailsRequest
     PRICE_LEVEL("price_level"),
     RATING("rating"),
     REFERENCE("reference"),
-    REVIEWS("reviews"),
+    REVIEW("review"),
     SCOPE("scope"),
     TYPES("types"),
     URL("url"),


### PR DESCRIPTION
According to the official docs, the field should be called "review", not "reviews". It appears that "reviews" also work, but the correct term is "review". More info in the doc:
https://developers.google.com/places/web-service/details#fields