### PR TITLE
Add StaticMapsRequest.path(EncodedPolyline)

### DIFF
--- a/src/main/java/com/google/maps/StaticMapsRequest.java
+++ b/src/main/java/com/google/maps/StaticMapsRequest.java
@@ -18,6 +18,7 @@ package com.google.maps;
 import com.google.maps.internal.ApiConfig;
 import com.google.maps.internal.StringJoin;
 import com.google.maps.internal.StringJoin.UrlValue;
+import com.google.maps.model.EncodedPolyline;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.Size;
 import java.util.ArrayList;
@@ -430,6 +431,17 @@ public class StaticMapsRequest
    */
   public StaticMapsRequest path(Path path) {
     return paramAddToList("path", path);
+  }
+
+  /**
+   * The <code>path</code> parameter defines a set of one or more locations connected by a path to
+   * overlay on the map image. This variant of the method accepts the path as an EncodedPolyline.
+   *
+   * @param path A path to render atop the map, as an EncodedPolyline.
+   * @return Returns this {@code StaticMapsRequest} for call chaining.
+   */
+  public StaticMapsRequest path(EncodedPolyline path) {
+    return paramAddToList("path", "enc:" + path.getEncodedPath());
   }
 
   /**


### PR DESCRIPTION
Closes #233.

This adds a `StaticMapsRequest.path(path)` variant that accepts an `EncodedPolyline` as the `path` argument. It uses the encoded polyline in the request it produces.

The test case EncodedPolyline was produced using https://github.com/apjanke/gmsj-cli/commit/599cee7e09b9824c61e03223de570d27e3eb1e5e. It seems to produce a correctly formatted request. I have not tested it by actually running the requests against the Google Maps API server, though.