### PR TITLE
DirectionsLeg, TransitDetails: use ZonedDateTime instead of LocalDateTime

### DIFF
--- a/src/main/java/com/google/maps/internal/GaePendingResult.java
+++ b/src/main/java/com/google/maps/internal/GaePendingResult.java
@@ -43,8 +43,8 @@ import com.google.maps.model.TravelMode;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -166,7 +166,7 @@ public class GaePendingResult<T, R extends ApiResponse<T>> implements PendingRes
 
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(LocalDateTime.class, new DateTimeAdapter())
+            .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeAdapter())
             .registerTypeAdapter(Distance.class, new DistanceAdapter())
             .registerTypeAdapter(Duration.class, new DurationAdapter())
             .registerTypeAdapter(Fare.class, new FareAdapter())

--- a/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
+++ b/src/main/java/com/google/maps/internal/OkHttpPendingResult.java
@@ -36,8 +36,8 @@ import com.google.maps.model.PriceLevel;
 import com.google.maps.model.TravelMode;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -240,7 +240,7 @@ public class OkHttpPendingResult<T, R extends ApiResponse<T>>
 
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(LocalDateTime.class, new DateTimeAdapter())
+            .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeAdapter())
             .registerTypeAdapter(Distance.class, new DistanceAdapter())
             .registerTypeAdapter(Duration.class, new DurationAdapter())
             .registerTypeAdapter(Fare.class, new FareAdapter())

--- a/src/main/java/com/google/maps/internal/ZonedDateTimeAdapter.java
+++ b/src/main/java/com/google/maps/internal/ZonedDateTimeAdapter.java
@@ -21,20 +21,20 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 /**
- * This class handles conversion from JSON to {@link LocalDateTime}s.
+ * This class handles conversion from JSON to {@link ZonedDateTime}s.
  *
  * <p>Please see <a
  * href="https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/TypeAdapter.html">TypeAdapter</a>
  * for more detail.
  */
-public class DateTimeAdapter extends TypeAdapter<LocalDateTime> {
+public class ZonedDateTimeAdapter extends TypeAdapter<ZonedDateTime> {
 
   /**
-   * Read a Time object from a Directions API result and convert it to a {@link LocalDateTime}.
+   * Read a Time object from a Directions API result and convert it to a {@link ZonedDateTime}.
    *
    * <p>We are expecting to receive something akin to the following:
    *
@@ -47,7 +47,7 @@ public class DateTimeAdapter extends TypeAdapter<LocalDateTime> {
    * </pre>
    */
   @Override
-  public LocalDateTime read(JsonReader reader) throws IOException {
+  public ZonedDateTime read(JsonReader reader) throws IOException {
     if (reader.peek() == JsonToken.NULL) {
       reader.nextNull();
       return null;
@@ -70,13 +70,13 @@ public class DateTimeAdapter extends TypeAdapter<LocalDateTime> {
     }
     reader.endObject();
 
-    return LocalDateTime.ofInstant(
+    return ZonedDateTime.ofInstant(
         Instant.ofEpochMilli(secondsSinceEpoch * 1000), ZoneId.of(timeZoneId));
   }
 
   /** This method is not implemented. */
   @Override
-  public void write(JsonWriter writer, LocalDateTime value) throws IOException {
+  public void write(JsonWriter writer, ZonedDateTime value) throws IOException {
     throw new UnsupportedOperationException("Unimplemented method");
   }
 }

--- a/src/main/java/com/google/maps/model/DirectionsLeg.java
+++ b/src/main/java/com/google/maps/model/DirectionsLeg.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 /**
  * A component of a Directions API result.
@@ -58,13 +58,13 @@ public class DirectionsLeg implements Serializable {
    * The estimated time of arrival for this leg. This property is only returned for transit
    * directions.
    */
-  public LocalDateTime arrivalTime;
+  public ZonedDateTime arrivalTime;
 
   /**
    * The estimated time of departure for this leg. The departureTime is only available for transit
    * directions.
    */
-  public LocalDateTime departureTime;
+  public ZonedDateTime departureTime;
 
   /**
    * The latitude/longitude coordinates of the origin of this leg. Because the Directions API

--- a/src/main/java/com/google/maps/model/TransitDetails.java
+++ b/src/main/java/com/google/maps/model/TransitDetails.java
@@ -16,7 +16,7 @@
 package com.google.maps.model;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Transit directions return additional information that is not relevant for other modes of
@@ -36,10 +36,10 @@ public class TransitDetails implements Serializable {
   public StopDetails departureStop;
 
   /** The arrival time for this leg of the journey. */
-  public LocalDateTime arrivalTime;
+  public ZonedDateTime arrivalTime;
 
   /** The departure time for this leg of the journey. */
-  public LocalDateTime departureTime;
+  public ZonedDateTime departureTime;
 
   /**
    * The direction in which to travel on this line, as it is marked on the vehicle or at the


### PR DESCRIPTION
This preserves the time zone information from the API response data.

This is a breaking change to the public API! Per the discussion at https://github.com/googlemaps/google-maps-services-java/issues/514#issuecomment-441160366, this should be okay.