### PR TITLE
Force Jacoco version 0.8.2 for OpenJDK 11 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ javadoc {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.2" // non-default version 0.8.2 required for OpenJDK 11 compatibility
+}
+
 jacocoTestReport {
     reports {
         xml.enabled = true // coveralls plugin depends on xml format report


### PR DESCRIPTION
The jacoco Gradle plugin seems to be defaulting to Jacoco 0.8.1, which breaks when run against OpenJDK 11. This PR adds an explicit version to force it to use 0.8.2.

JDK 11 support was added recently and picked up in Jacoco 0.8.2: https://github.com/jacoco/jacoco/issues/663

This fixes test errors as seen in https://github.com/googlemaps/google-maps-services-java/pull/513#issuecomment-439308531, which look like the following.

```
FATAL ERROR in native method: processing of -javaagent failed
Caused by: java.lang.NoSuchFieldException: $jacocoAccess
        at java.base/java.lang.Class.getField(Class.java:2000)
        at org.jacoco.agent.rt.internal_c13123e.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:138)
        ... 9 more
Process 'Gradle Test Executor 9' finished with non-zero exit value 134
org.gradle.process.internal.ExecException: Process 'Gradle Test Executor 9' finished with non-zero exit value 134
        at org.gradle.process.internal.DefaultExecHandle$ExecResultImpl.assertNormalExitValue(DefaultExecHandle.java:395)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.onProcessStop(DefaultWorkerProcess.java:138)
[...]
```