### PR TITLE
Added support to Place IDs

### DIFF
--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -230,7 +230,7 @@ public class DirectionsApiRequest
    * Specifies the list of waypoints as String addresses.
    * If any of the Strings are Place IDs, you must prefix them with {@code place_id:}.
    *
-   * <p>See {@link #prefixPlaceId()}.
+   * <p>See {@link #prefixPlaceId(String)}.
    * <p>See {@link #waypoints(Waypoint...)}.
    *
    * @param waypoints The waypoints to add to this directions request.
@@ -248,7 +248,7 @@ public class DirectionsApiRequest
    * Specifies the list of waypoints as Plade ID Strings, prefixing them as required by
    * the API.
    *
-   * <p>See {@link #prefixPlaceId()}.
+   * <p>See {@link #prefixPlaceId(String)}.
    * <p>See {@link #waypoints(Waypoint...)}.
    *
    * @param waypoints The waypoints to add to this directions request.

--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -81,6 +81,26 @@ public class DirectionsApiRequest
   public DirectionsApiRequest destination(String destination) {
     return param("destination", destination);
   }
+    
+  /**
+   * The Place ID value from which you wish to calculate directions.
+   *
+   * @param originPlaceId The starting location Place ID for the Directions request.
+   * @return Returns this {@code DirectionsApiRequest} for call chaining.
+   */
+  public DirectionsApiRequest originPlaceId(String originPlaceId) {
+    return param("origin", prefixPlaceId(originPlaceId));
+  }
+    
+  /**
+   * The Place ID value from which you wish to calculate directions.
+   *
+   * @param destinationPlaceId The ending location Place ID for the Directions request.
+   * @return Returns this {@code DirectionsApiRequest} for call chaining.
+   */
+  public DirectionsApiRequest destinationPlaceId(String destinationPlaceId) {
+    return param("destination", prefixPlaceId(destinationPlaceId));
+  }
 
   /**
    * The origin, as a latitude/longitude location.
@@ -208,7 +228,9 @@ public class DirectionsApiRequest
 
   /**
    * Specifies the list of waypoints as String addresses.
+   * If any of the Strings are Place IDs, you must prefix them with {@code place_id:}.
    *
+   * <p>See {@link #prefixPlaceId()}.
    * <p>See {@link #waypoints(Waypoint...)}.
    *
    * @param waypoints The waypoints to add to this directions request.
@@ -301,6 +323,16 @@ public class DirectionsApiRequest
    */
   public DirectionsApiRequest trafficModel(TrafficModel trafficModel) {
     return param("traffic_model", trafficModel);
+  }
+    
+  /**
+   * Helper method for prefixing a Place ID, as specified by the API.
+   *
+   * @param placeId The Place ID to be prefixed.
+   * @return Returns the Place ID prefixed with {@code place_id:}.
+   */
+  public String prefixPlaceId(String placeId) {
+    return "place_id:" + placeId;
   }
 
   public static class Waypoint {

--- a/src/main/java/com/google/maps/DirectionsApiRequest.java
+++ b/src/main/java/com/google/maps/DirectionsApiRequest.java
@@ -243,6 +243,24 @@ public class DirectionsApiRequest
     }
     return waypoints(objWaypoints);
   }
+    
+  /**
+   * Specifies the list of waypoints as Plade ID Strings, prefixing them as required by
+   * the API.
+   *
+   * <p>See {@link #prefixPlaceId()}.
+   * <p>See {@link #waypoints(Waypoint...)}.
+   *
+   * @param waypoints The waypoints to add to this directions request.
+   * @return Returns this {@code DirectionsApiRequest} for call chaining.
+   */
+  public DirectionsApiRequest waypointsFromPlaceIds(String... waypoints) {
+    Waypoint[] objWaypoints = new Waypoint[waypoints.length];
+    for (int i = 0; i < waypoints.length; i++) {
+      objWaypoints[i] = new Waypoint(prefixPlaceId(waypoints[i]));
+    }
+    return waypoints(objWaypoints);
+  }
 
   /**
    * The list of waypoints as latitude/longitude locations.


### PR DESCRIPTION
Place IDs can be provided as origin, destination and waypoints. But in order to be used, they must be prefixed with `place_id:`.

I took the liberty of implementing this, so I added new methods for setting an origin and a destination as a Place ID, as well as a method to set waypoints based on Place IDs, There's a new helper method for prefixing Place IDs, which could be used to pass Place IDs waypoints into the waypoints method that accepts Strings, alongside addresses. This way users can mix addresses and Place IDs if they want to. 