### PR TITLE
TextSearch: add region parameter

### DIFF
--- a/src/main/java/com/google/maps/TextSearchRequest.java
+++ b/src/main/java/com/google/maps/TextSearchRequest.java
@@ -62,6 +62,19 @@ public class TextSearchRequest
   }
 
   /**
+   * Region used to influence search results. This parameter will only influence, not fully
+   * restrict, search results. If more relevant results exist outside of the specified region, they
+   * may be included. When this parameter is used, the country name is omitted from the resulting
+   * formatted_address for results in the specified region.
+   *
+   * @param region The ccTLD two-letter code of the region.
+   * @return Returns this {@code TextSearchRequest} for call chaining.
+   */
+  public TextSearchRequest region(String region) {
+    return param("region", region);
+  }
+
+  /**
    * Specifies the distance (in meters) within which to bias place results.
    *
    * @param radius The radius of the search bias.

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -448,6 +448,7 @@ public class PlacesApiTest {
       LatLng location = new LatLng(10, 20);
       PlacesApi.textSearchQuery(sc.context, "Google Sydney")
           .location(location)
+          .region("AU")
           .radius(3000)
           .minPrice(PriceLevel.INEXPENSIVE)
           .maxPrice(PriceLevel.VERY_EXPENSIVE)
@@ -459,6 +460,7 @@ public class PlacesApiTest {
 
       sc.assertParamValue("Google Sydney", "query");
       sc.assertParamValue(location.toUrlValue(), "location");
+      sc.assertParamValue("AU", "region");
       sc.assertParamValue(String.valueOf(3000), "radius");
       sc.assertParamValue(String.valueOf(1), "minprice");
       sc.assertParamValue(String.valueOf(4), "maxprice");


### PR DESCRIPTION
Fixes #534.

Adds a `region` parameter to the Places TextSearch request.

Here's support in the gmsj-cli command line driver for interactive testing: https://github.com/apjanke/gmsj-cli/commit/894deda41456c0a4c73e78c44f7f93709532be4e.