### PR TITLE
Add meal_delivery AddressComponentType

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -259,6 +259,9 @@ public enum AddressComponentType {
   /** An RV park. */
   RV_PARK("rv_park"),
 
+  /** A meal delivery establishment. */
+  MEAL_DELIVERY("meal_delivery"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -273,6 +273,7 @@ public class EnumsTest {
     m.put(AddressComponentType.MUSEUM, "museum");
     m.put(AddressComponentType.RV_PARK, "rv_park");
     m.put(AddressComponentType.CAMPGROUND, "campground");
+    m.put(AddressComponentType.MEAL_DELIVERY, "meal_delivery");
 
     for (Map.Entry<AddressComponentType, String> AddressComponentTypeLiteralPair :
         addressComponentTypeToLiteralMap.entrySet()) {


### PR DESCRIPTION
I saw the following error from google-maps-services this morning:

`Unknown type for enum com.google.maps.model.AddressComponentType: 'meal_delivery'`

So I thought I'd take the initiative and add it as a new `AddressComponentType`.