### PR TITLE
Add Light Rail Station into PlaceType

### DIFF
--- a/src/main/java/com/google/maps/model/PlaceType.java
+++ b/src/main/java/com/google/maps/model/PlaceType.java
@@ -74,6 +74,7 @@ public enum PlaceType implements StringJoin.UrlValue {
   LAUNDRY("laundry"),
   LAWYER("lawyer"),
   LIBRARY("library"),
+  LIGHT_RAIL_STATION("light_rail_station"),
   LIQUOR_STORE("liquor_store"),
   LOCAL_GOVERNMENT_OFFICE("local_government_office"),
   LOCKSMITH("locksmith"),


### PR DESCRIPTION
I found out that `light_rail_station` is supported as PlaceType. However, it's not [documented](https://developers.google.com/places/web-service/supported_types), so I'm not sure about this, WDYT?