### PR TITLE
Validate TextSearchRequest without query if type is set

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Amy Boyd <amy@amyboyd.co.uk> @amyboyd
 Brantley Wells <brantleywells@gmail.com> @gitbrantley
 Brett Morgan <brettmorgan@google.com> @domesticmouse
 Chris Broadfoot <cbro@google.com> @broady
+Dan O'Meara <danom@google.com> @danoscarmike
 Dave Holmes <daveholmes@google.com> @dh--
 Ismael Blesa <isma.work@gmail.com> @ismamai
 Malcolm Windsor <malcolm@beoped.com> @mwindsor-beoped

--- a/src/main/java/com/google/maps/TextSearchRequest.java
+++ b/src/main/java/com/google/maps/TextSearchRequest.java
@@ -168,8 +168,9 @@ public class TextSearchRequest
       return;
     }
 
-    if (!params().containsKey("query")) {
-      throw new IllegalArgumentException("Request must contain 'query' or a 'pageToken'.");
+    if (!params().containsKey("query") && !params().containsKey("type")) {
+      throw new IllegalArgumentException(
+              "Request must contain 'query' or a 'pageToken'. If a 'type' is specified 'query' becomes optional.");
     }
 
     if (params().containsKey("location") && !params().containsKey("radius")) {


### PR DESCRIPTION
Updated logic in `validateRequest` method of `TextSearchRequest` class

Fixes #564 