### PR TITLE
[NOT URGENT] add new textSearchQuery (overload) method with test

### DIFF
--- a/src/main/java/com/google/maps/PlacesApi.java
+++ b/src/main/java/com/google/maps/PlacesApi.java
@@ -16,6 +16,7 @@
 package com.google.maps;
 
 import com.google.maps.model.LatLng;
+import com.google.maps.model.PlaceType;
 
 /**
  * Performs a text search for places. The Google Places API enables you to get data from the same
@@ -70,6 +71,19 @@ public class PlacesApi {
   public static TextSearchRequest textSearchQuery(GeoApiContext context, String query) {
     TextSearchRequest request = new TextSearchRequest(context);
     request.query(query);
+    return request;
+  }
+
+  /**
+   * Performs a search for Places using a PlaceType parameter.
+   *
+   * @param context The context on which to make Geo API requests.
+   * @param type Restricts the results to places matching the specified PlaceType.
+   * @return Returns a TextSearchRequest that can be configured and executed.
+   */
+  public static TextSearchRequest textSearchQuery(GeoApiContext context, PlaceType type) {
+    TextSearchRequest request = new TextSearchRequest(context);
+    request.type(type);
     return request;
   }
 

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -471,6 +471,21 @@ public class PlacesApiTest {
     }
   }
 
+  @Test
+  public void testTextSearchRequestWithType() throws Exception {
+    try (LocalTestServerContext sc = new LocalTestServerContext("{\"status\" : \"OK\"}")) {
+      LatLng location = new LatLng(-33.866611, 151.195832);
+      PlacesSearchResponse results = PlacesApi.textSearchQuery(sc.context, PlaceType.ESTABLISHMENT)
+              .location(location)
+              .radius(500)
+              .await();
+
+      sc.assertParamValue(location.toUrlValue(), "location");
+      sc.assertParamValue(String.valueOf(500), "radius");
+      sc.assertParamValue(PlaceType.ESTABLISHMENT.toString(), "type");
+    }
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testTextSearchLocationWithoutRadius() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext("{\"status\" : \"OK\"}")) {


### PR DESCRIPTION
This PR implements my suggestion in #566 

Adds new overload to `PlacesApi.textSearchQuery` method for cases where the user wants to pass a `type` but no `query`. This is allowable according to the [docs](https://developers.google.com/places/web-service/search#TextSearchRequests) and tests pass.