### PR TITLE
Fix: Format java files that break tests using gradlew check

### DIFF
--- a/src/main/java/com/google/maps/TextSearchRequest.java
+++ b/src/main/java/com/google/maps/TextSearchRequest.java
@@ -170,7 +170,7 @@ public class TextSearchRequest
 
     if (!params().containsKey("query") && !params().containsKey("type")) {
       throw new IllegalArgumentException(
-              "Request must contain 'query' or a 'pageToken'. If a 'type' is specified 'query' becomes optional.");
+          "Request must contain 'query' or a 'pageToken'. If a 'type' is specified 'query' becomes optional.");
     }
 
     if (params().containsKey("location") && !params().containsKey("radius")) {

--- a/src/main/java/com/google/maps/model/PlacesSearchResult.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResult.java
@@ -74,7 +74,7 @@ public class PlacesSearchResult implements Serializable {
   /** Indicates that the place has permanently shut down. */
   public boolean permanentlyClosed;
 
-  /** The number of user reviews for this place*/
+  /** The number of user reviews for this place */
   public int userRatingsTotal;
 
   @Override

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -475,7 +475,8 @@ public class PlacesApiTest {
   public void testTextSearchRequestWithType() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext("{\"status\" : \"OK\"}")) {
       LatLng location = new LatLng(-33.866611, 151.195832);
-      PlacesSearchResponse results = PlacesApi.textSearchQuery(sc.context, PlaceType.ESTABLISHMENT)
+      PlacesSearchResponse results =
+          PlacesApi.textSearchQuery(sc.context, PlaceType.ESTABLISHMENT)
               .location(location)
               .radius(500)
               .await();
@@ -785,9 +786,9 @@ public class PlacesApiTest {
   @Test
   public void testNearbySearchRequestByTypeReturnsUserRatingsTotal() throws Exception {
     try (LocalTestServerContext sc =
-                 new LocalTestServerContext(placesApiNearbySearchRequestByType)) {
+        new LocalTestServerContext(placesApiNearbySearchRequestByType)) {
       PlacesSearchResponse response =
-              PlacesApi.nearbySearchQuery(sc.context, SYDNEY).radius(10000).type(PlaceType.BAR).await();
+          PlacesApi.nearbySearchQuery(sc.context, SYDNEY).radius(10000).type(PlaceType.BAR).await();
 
       assertEquals(20, response.results.length);
       assertEquals(563, response.results[0].userRatingsTotal);


### PR DESCRIPTION
Fixes the broken Travis tests by ensuring `./gradlew check` passes.

### Logs
```
./gradlew check

> Task :test
objc[56081]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/bin/java (0x10ccbf4c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x10cd434e0). One of the two will be used. Which one is undefined.

> Task :verifyGoogleJavaFormat FAILED


The following files are not formatted properly:

/Users/timmerman/Documents/github/grant/google-maps-services-java/src/test/java/com/google/maps/PlacesApiTest.java
/Users/timmerman/Documents/github/grant/google-maps-services-java/src/main/java/com/google/maps/TextSearchRequest.java
/Users/timmerman/Documents/github/grant/google-maps-services-java/src/main/java/com/google/maps/model/PlacesSearchResult.java

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':verifyGoogleJavaFormat'.
> Problems: formatting style violations

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 31s
6 actionable tasks: 6 executed
timmerman @ ⎇ (grant_fix_tests) ~/Documents/github/grant/google-maps-services-java
❤ ./gradlew check

> Task :test
objc[56668]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/bin/java (0x1072354c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x1072b94e0). One of the two will be used. Which one is undefined.

BUILD SUCCESSFUL in 31s
6 actionable tasks: 5 executed, 1 up-to-date
timmerman @ ⎇ (grant_fix_tests) ~/Documents/github/grant/google-maps-services-java
```

Observe `FAILURE` -> `BUILD SUCCESSFUL`.

CC: @domesticmouse