### PR TITLE
Include plus_code in PlaceDetailsRequest.FieldMask

### DIFF
--- a/src/main/java/com/google/maps/PlaceDetailsRequest.java
+++ b/src/main/java/com/google/maps/PlaceDetailsRequest.java
@@ -132,6 +132,7 @@ public class PlaceDetailsRequest
     USER_RATINGS_TOTAL("user_ratings_total"),
     PHOTOS("photos"),
     PLACE_ID("place_id"),
+    PLUS_CODE("plus_code"),
     PRICE_LEVEL("price_level"),
     RATING("rating"),
     REFERENCE("reference"),


### PR DESCRIPTION
Without it you can't request a subset of fields in a details request that includes `plus_code`.