### PR TITLE
deprecation warning for place fields: `alt_id`, `id`, `reference`, and `scope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/googlemaps/google-maps-services-java/compare/v0.10.0...HEAD)
+### Changed
+- deprecation warning for place fields: `alt_id`, `id`, `reference`, and `scope`. Read more about this at https://developers.google.com/maps/deprecations.
 
 ## [v0.10.1](https://github.com/googlemaps/google-maps-services-java/compare/v0.10.0...v0.10.1) - 2019-09-23
 

--- a/src/main/java/com/google/maps/PlaceDetailsRequest.java
+++ b/src/main/java/com/google/maps/PlaceDetailsRequest.java
@@ -119,6 +119,7 @@ public class PlaceDetailsRequest
   public enum FieldMask implements UrlValue {
     ADDRESS_COMPONENT("address_component"),
     ADR_ADDRESS("adr_address"),
+    @Deprecated
     ALT_ID("alt_id"),
     FORMATTED_ADDRESS("formatted_address"),
     FORMATTED_PHONE_NUMBER("formatted_phone_number"),
@@ -134,6 +135,7 @@ public class PlaceDetailsRequest
     GEOMETRY_VIEWPORT_SOUTHWEST_LAT("geometry/viewport/southwest/lat"),
     GEOMETRY_VIEWPORT_SOUTHWEST_LNG("geometry/viewport/southwest/lng"),
     ICON("icon"),
+    @Deprecated
     ID("id"),
     INTERNATIONAL_PHONE_NUMBER("international_phone_number"),
     NAME("name"),
@@ -145,8 +147,10 @@ public class PlaceDetailsRequest
     PLUS_CODE("plus_code"),
     PRICE_LEVEL("price_level"),
     RATING("rating"),
+    @Deprecated
     REFERENCE("reference"),
     REVIEW("review"),
+    @Deprecated
     SCOPE("scope"),
     TYPES("types"),
     URL("url"),

--- a/src/main/java/com/google/maps/model/PlaceIdScope.java
+++ b/src/main/java/com/google/maps/model/PlaceIdScope.java
@@ -16,6 +16,7 @@
 package com.google.maps.model;
 
 /** The scope of a Place ID returned from the Google Places API Web Service. */
+@Deprecated
 public enum PlaceIdScope {
   /**
    * Indicates the place ID is recognised by your application only. This is because your application

--- a/src/main/java/com/google/maps/model/PlacesSearchResult.java
+++ b/src/main/java/com/google/maps/model/PlacesSearchResult.java
@@ -54,7 +54,7 @@ public class PlacesSearchResult implements Serializable {
   public String placeId;
 
   /** The scope of the placeId. */
-  public PlaceIdScope scope;
+  @Deprecated public PlaceIdScope scope;
 
   /** The place's rating, from 1.0 to 5.0, based on aggregated user reviews. */
   public float rating;
@@ -83,7 +83,7 @@ public class PlacesSearchResult implements Serializable {
     sb.append("\"").append(name).append("\"");
     sb.append(", \"").append(formattedAddress).append("\"");
     sb.append(", geometry=").append(geometry);
-    sb.append(", placeId=").append(placeId).append(" (").append(scope).append(" )");
+    sb.append(", placeId=").append(placeId);
     if (vicinity != null) {
       sb.append(", vicinity=").append(vicinity);
     }

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -41,7 +41,6 @@ import com.google.maps.model.Photo;
 import com.google.maps.model.PlaceAutocompleteType;
 import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceDetails.Review.AspectRating.RatingType;
-import com.google.maps.model.PlaceIdScope;
 import com.google.maps.model.PlaceType;
 import com.google.maps.model.PlacesSearchResponse;
 import com.google.maps.model.PlacesSearchResult;
@@ -320,8 +319,6 @@ public class PlacesApiTest {
       // Place ID
       assertNotNull(placeDetails.placeId);
       assertEquals(placeDetails.placeId, GOOGLE_SYDNEY);
-      assertNotNull(placeDetails.scope);
-      assertEquals(placeDetails.scope, PlaceIdScope.GOOGLE);
       assertNotNull(placeDetails.types);
       assertEquals(placeDetails.types[0], AddressType.ESTABLISHMENT);
       assertEquals(placeDetails.rating, 4.4, 0.1);


### PR DESCRIPTION
Place fields, `alt_id`, `id`, `reference`, and `scope`, are now deprecated. This annotates these objects as such. Read more about this at https://developers.google.com/maps/deprecations.

closes #604 