### PR TITLE
Add missing Address and AddressComponent Types

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -262,6 +262,21 @@ public enum AddressComponentType {
   /** A meal delivery establishment. */
   MEAL_DELIVERY("meal_delivery"),
 
+  /** A spa. */
+  SPA("spa"),
+
+  /** A tourist attraction. */
+  TOURIST_ATTRACTION("tourist_attraction"),
+
+  /** A university. */
+  UNIVERSITY("university"),
+
+  /** An amusement park. */
+  AMUSEMENT_PARK("amusement_park"),
+
+  /** A hardware store. */
+  HARDWARE_STORE("hardware_store"),
+
   /**
    * Indicates an unknown address component type returned by the server. The Java Client for Google
    * Maps Services should be updated to support the new value.

--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -281,6 +281,12 @@ public enum AddressType implements UrlValue {
   /** Currently not a documented return type. */
   SCHOOL("school"),
 
+  /** A primary school. */
+  PRIMARY_SCHOOL("primary_school"),
+
+  /** A secondary school. */
+  SECONDARY_SCHOOL("secondary_school"),
+
   /** Currently not a documented return type. */
   BOOK_STORE("book_store"),
 
@@ -448,6 +454,9 @@ public enum AddressType implements UrlValue {
 
   /** A tourist attraction */
   TOURIST_ATTRACTION("tourist_attraction"),
+
+  /** A drugstore. */
+  DRUGSTORE("drugstore"),
 
   /**
    * Indicates an unknown address type returned by the server. The Java Client for Google Maps

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -124,6 +124,8 @@ public class EnumsTest {
     m.put(AddressType.BAKERY, "bakery");
     m.put(AddressType.PHARMACY, "pharmacy");
     m.put(AddressType.SCHOOL, "school");
+    m.put(AddressType.PRIMARY_SCHOOL, "primary_school");
+    m.put(AddressType.SECONDARY_SCHOOL, "secondary_school");
     m.put(AddressType.BOOK_STORE, "book_store");
     m.put(AddressType.DEPARTMENT_STORE, "department_store");
     m.put(AddressType.RESTAURANT, "restaurant");
@@ -180,6 +182,7 @@ public class EnumsTest {
     m.put(AddressType.ZOO, "zoo");
     m.put(AddressType.ARCHIPELAGO, "archipelago");
     m.put(AddressType.TOURIST_ATTRACTION, "tourist_attraction");
+    m.put(AddressType.DRUGSTORE, "drugstore");
 
     for (Map.Entry<AddressType, String> addressTypeLiteralPair :
         addressTypeToLiteralMap.entrySet()) {
@@ -275,6 +278,11 @@ public class EnumsTest {
     m.put(AddressComponentType.RV_PARK, "rv_park");
     m.put(AddressComponentType.CAMPGROUND, "campground");
     m.put(AddressComponentType.MEAL_DELIVERY, "meal_delivery");
+    m.put(AddressComponentType.SPA, "spa");
+    m.put(AddressComponentType.TOURIST_ATTRACTION, "tourist_attraction");
+    m.put(AddressComponentType.UNIVERSITY, "university");
+    m.put(AddressComponentType.AMUSEMENT_PARK, "amusement_park");
+    m.put(AddressComponentType.HARDWARE_STORE, "hardware_store");
 
     for (Map.Entry<AddressComponentType, String> AddressComponentTypeLiteralPair :
         addressComponentTypeToLiteralMap.entrySet()) {


### PR DESCRIPTION
The API started returning new types for the Address and AddressComponents. These missing types generate warnings.