### PR TITLE
documentation problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ life of your application. This will enable proper QPS enforcement across all of 
 At the end of the execution, call the `shutdown()` method of `GeoApiContext`,
 otherwise the thread will remain instantiated in memory.
 
-
-
 For more usage examples, check out [the tests](src/test/java/com/google/maps).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ You can find the latest version at the top of this README or by [searching
 Maven Central](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22google-maps-services%22) or [Gradle, Please](http://gradleplease.appspot.com/#google-maps-services).
 
 ## Developer Documentation
- 
 View the [javadoc](https://www.javadoc.io/doc/com.google.maps/google-maps-services).
 
 Additional documentation for the included web services is available at

--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ The `GeoApiContext` is designed to be a [Singleton](https://en.wikipedia.org/wik
 in your application. Please instantiate one on application startup, and continue to use it for the
 life of your application. This will enable proper QPS enforcement across all of your requests.
 
+at the end of the execution, call the `shutdown()` method of `GeoApiContext`,
+otherwise the thread will remain instantiated in memory.
+
+
+
 For more usage examples, check out [the tests](src/test/java/com/google/maps).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The `GeoApiContext` is designed to be a [Singleton](https://en.wikipedia.org/wik
 in your application. Please instantiate one on application startup, and continue to use it for the
 life of your application. This will enable proper QPS enforcement across all of your requests.
 
-at the end of the execution, call the `shutdown()` method of `GeoApiContext`,
+At the end of the execution, call the `shutdown()` method of `GeoApiContext`,
 otherwise the thread will remain instantiated in memory.
 
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find the latest version at the top of this README or by [searching
 Maven Central](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22google-maps-services%22) or [Gradle, Please](http://gradleplease.appspot.com/#google-maps-services).
 
 ## Developer Documentation
-
+ 
 View the [javadoc](https://www.javadoc.io/doc/com.google.maps/google-maps-services).
 
 Additional documentation for the included web services is available at


### PR DESCRIPTION
in the readme file, the call of the shutdown () method is not specified at the end of a request.

this is a problem because after n requests java creates multiple threads not closed
and in the case of tomcat the instance goes into error