### PR TITLE
fixed: Added path exception when there is no center or no zoom

### DIFF
--- a/src/main/java/com/google/maps/StaticMapsRequest.java
+++ b/src/main/java/com/google/maps/StaticMapsRequest.java
@@ -37,9 +37,10 @@ public class StaticMapsRequest
   @Override
   protected void validateRequest() {
     if (!((params().containsKey("center") && params().containsKey("zoom"))
-        || params().containsKey("markers"))) {
+        || params().containsKey("markers")
+        || params().containsKey("path"))) {
       throw new IllegalArgumentException(
-          "Request must contain 'center' and 'zoom' if 'markers' isn't present.");
+          "Request must contain 'center' and 'zoom' if 'markers' or 'path' aren't present.");
     }
     if (!params().containsKey("size")) {
       throw new IllegalArgumentException("Request must contain 'size'.");

--- a/src/test/java/com/google/maps/StaticMapsApiTest.java
+++ b/src/test/java/com/google/maps/StaticMapsApiTest.java
@@ -123,6 +123,39 @@ public class StaticMapsApiTest {
     }
   }
 
+  @Test
+  public void testValidateRequest_noCenterAndNoZoomWithMarkers() throws Exception {
+    try (LocalTestServerContext sc = new LocalTestServerContext(IMAGE)) {
+      StaticMapsRequest req = StaticMapsApi.newRequest(sc.context, new Size(WIDTH, HEIGHT));
+
+      Markers markers = new Markers();
+      markers.size(MarkersSize.small);
+      markers.customIcon("http://not.a/real/url", CustomIconAnchor.bottomleft, 2);
+      markers.color("blue");
+      markers.label("A");
+      markers.addLocation("Melbourne");
+      markers.addLocation(SYDNEY);
+      req.markers(markers);
+      req.await();
+    }
+  }
+
+  @Test
+  public void testValidateRequest_noCenterAndNoZoomWithPath() throws Exception {
+    try (LocalTestServerContext sc = new LocalTestServerContext(IMAGE)) {
+      StaticMapsRequest req = StaticMapsApi.newRequest(sc.context, new Size(WIDTH, HEIGHT));
+      Path path = new Path();
+      path.color("green");
+      path.fillcolor("0xAACCEE");
+      path.weight(3);
+      path.geodesic(true);
+      path.addPoint("Melbourne");
+      path.addPoint(SYDNEY);
+      req.path(path);
+      req.await();
+    }
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testValidateRequest_noSize() throws Exception {
     try (LocalTestServerContext sc = new LocalTestServerContext(IMAGE)) {


### PR DESCRIPTION
We saw in the documentation (https://developers.google.com/maps/documentation/maps-static/dev-guide?hl=es#ImplicitPositioning ) these lines:

"Normally, you need to specify center and zoom URL parameters to define the location and zoom level of your generated map. However, if you supply markers, path, or visible parameters, you can instead let the Maps Static API determine the correct center and zoom level implicitly, based on evaluation of the position of these elements."