### PR TITLE
build(Gradle): upgrade gradle wrapper to 6.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,11 @@ tasks.withType(Test) {
     systemProperty 'client.secret', System.getProperty('client.secret')
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 javadoc {
     exclude '**/internal/**'
     def currentJavaVersion = org.gradle.api.JavaVersion.current()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
- Upgrading Gradle wrapper to 6.1.1
- Adding `withJavadocJar` & `withJavadocJar` to ensure that javadoc + sources .jar are published when running `./gradlew publish`

I verified that this works when manually running `./gradlew publish`. Still need to verify that this works with the deploy script that travis executes (we can verify this on the next release)