### PR TITLE
feat: Add hooks for performance logging

### DIFF
--- a/src/main/java/com/google/maps/GaeRequestHandler.java
+++ b/src/main/java/com/google/maps/GaeRequestHandler.java
@@ -29,6 +29,7 @@ import com.google.maps.internal.ApiResponse;
 import com.google.maps.internal.ExceptionsAllowedToRetry;
 import com.google.maps.internal.GaePendingResult;
 import com.google.maps.internal.HttpHeaders;
+import com.google.maps.metrics.RequestMetrics;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
@@ -57,7 +58,8 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       FieldNamingPolicy fieldNamingPolicy,
       long errorTimeout,
       Integer maxRetries,
-      ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
+      ExceptionsAllowedToRetry exceptionsAllowedToRetry,
+      RequestMetrics metrics) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req;
     try {
@@ -72,7 +74,14 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
     }
 
     return new GaePendingResult<>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req,
+        client,
+        clazz,
+        fieldNamingPolicy,
+        errorTimeout,
+        maxRetries,
+        exceptionsAllowedToRetry,
+        metrics);
   }
 
   @Override
@@ -86,7 +95,8 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
       FieldNamingPolicy fieldNamingPolicy,
       long errorTimeout,
       Integer maxRetries,
-      ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
+      ExceptionsAllowedToRetry exceptionsAllowedToRetry,
+      RequestMetrics metrics) {
     FetchOptions fetchOptions = FetchOptions.Builder.withDeadline(10);
     HTTPRequest req = null;
     try {
@@ -103,7 +113,14 @@ public class GaeRequestHandler implements GeoApiContext.RequestHandler {
     }
 
     return new GaePendingResult<>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req,
+        client,
+        clazz,
+        fieldNamingPolicy,
+        errorTimeout,
+        maxRetries,
+        exceptionsAllowedToRetry,
+        metrics);
   }
 
   @Override

--- a/src/main/java/com/google/maps/OkHttpRequestHandler.java
+++ b/src/main/java/com/google/maps/OkHttpRequestHandler.java
@@ -22,6 +22,7 @@ import com.google.maps.internal.ExceptionsAllowedToRetry;
 import com.google.maps.internal.HttpHeaders;
 import com.google.maps.internal.OkHttpPendingResult;
 import com.google.maps.internal.RateLimitExecutorService;
+import com.google.maps.metrics.RequestMetrics;
 import java.io.IOException;
 import java.net.Proxy;
 import java.util.concurrent.ExecutorService;
@@ -61,7 +62,8 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
       FieldNamingPolicy fieldNamingPolicy,
       long errorTimeout,
       Integer maxRetries,
-      ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
+      ExceptionsAllowedToRetry exceptionsAllowedToRetry,
+      RequestMetrics metrics) {
     Request.Builder builder = new Request.Builder().get().header("User-Agent", userAgent);
     if (experienceIdHeaderValue != null) {
       builder = builder.header(HttpHeaders.X_GOOG_MAPS_EXPERIENCE_ID, experienceIdHeaderValue);
@@ -69,7 +71,14 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
     Request req = builder.url(hostName + url).build();
 
     return new OkHttpPendingResult<>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req,
+        client,
+        clazz,
+        fieldNamingPolicy,
+        errorTimeout,
+        maxRetries,
+        exceptionsAllowedToRetry,
+        metrics);
   }
 
   @Override
@@ -83,7 +92,8 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
       FieldNamingPolicy fieldNamingPolicy,
       long errorTimeout,
       Integer maxRetries,
-      ExceptionsAllowedToRetry exceptionsAllowedToRetry) {
+      ExceptionsAllowedToRetry exceptionsAllowedToRetry,
+      RequestMetrics metrics) {
     RequestBody body = RequestBody.create(JSON, payload);
     Request.Builder builder = new Request.Builder().post(body).header("User-Agent", userAgent);
 
@@ -93,7 +103,14 @@ public class OkHttpRequestHandler implements GeoApiContext.RequestHandler {
     Request req = builder.url(hostName + url).build();
 
     return new OkHttpPendingResult<>(
-        req, client, clazz, fieldNamingPolicy, errorTimeout, maxRetries, exceptionsAllowedToRetry);
+        req,
+        client,
+        clazz,
+        fieldNamingPolicy,
+        errorTimeout,
+        maxRetries,
+        exceptionsAllowedToRetry,
+        metrics);
   }
 
   @Override

--- a/src/main/java/com/google/maps/metrics/NoOpRequestMetrics.java
+++ b/src/main/java/com/google/maps/metrics/NoOpRequestMetrics.java
@@ -1,0 +1,13 @@
+package com.google.maps.metrics;
+
+/** A no-op implementation that does nothing */
+final class NoOpRequestMetrics implements RequestMetrics {
+
+  NoOpRequestMetrics(String requestName) {}
+
+  public void startNetwork() {}
+
+  public void endNetwork() {}
+
+  public void endRequest(Exception exception, int httpStatusCode, long retryCount) {}
+}

--- a/src/main/java/com/google/maps/metrics/NoOpRequestMetricsReporter.java
+++ b/src/main/java/com/google/maps/metrics/NoOpRequestMetricsReporter.java
@@ -1,0 +1,11 @@
+package com.google.maps.metrics;
+
+/** A no-op implementation that does nothing */
+public final class NoOpRequestMetricsReporter implements RequestMetricsReporter {
+
+  public NoOpRequestMetricsReporter() {}
+
+  public RequestMetrics newRequest(String requestName) {
+    return new NoOpRequestMetrics(requestName);
+  }
+}

--- a/src/main/java/com/google/maps/metrics/RequestMetrics.java
+++ b/src/main/java/com/google/maps/metrics/RequestMetrics.java
@@ -1,0 +1,27 @@
+package com.google.maps.metrics;
+
+/**
+ * A type to report common metrics shared among all request types.
+ *
+ * <p>If a request retries, there will be multiple calls to all methods below. Ignore any endRequest
+ * after the first one. For example:
+ *
+ * <ol>
+ *   <li>constructor - request starts
+ *   <li>startNetwork / endNetwork - original request
+ *   <li>startNetwork / endNetwork - retried request
+ *   <li>endRequest - request finished (retry)
+ *   <li>endRequest - request finished (original)
+ * </ol>
+ *
+ * <p>The following metrics can be computed: Total queries, successful queries, total latency,
+ * network latency
+ */
+public interface RequestMetrics {
+
+  void startNetwork();
+
+  void endNetwork();
+
+  void endRequest(Exception exception, int httpStatusCode, long retryCount);
+}

--- a/src/main/java/com/google/maps/metrics/RequestMetricsReporter.java
+++ b/src/main/java/com/google/maps/metrics/RequestMetricsReporter.java
@@ -1,0 +1,7 @@
+package com.google.maps.metrics;
+
+/** A type to report common metrics shared among all request types. */
+public interface RequestMetricsReporter {
+
+  RequestMetrics newRequest(String requestName);
+}


### PR DESCRIPTION
Create hooks for detecting request timing and errors, as well as retries and network timing.
Add a default no-op handler that will not do anything.

This is setting up the interfaces for #663 🦕