### PR TITLE
feat: Add OpenCensus implementation for performance logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.76'
     api 'com.squareup.okhttp3:okhttp:3.14.4'
     api 'com.google.code.gson:gson:2.8.5'
+    api 'io.opencensus:opencensus-api:0.25.0'
     implementation 'org.slf4j:slf4j-api:1.7.26'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.0.0'
@@ -62,6 +63,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:1.7.26'
     testImplementation 'org.apache.commons:commons-lang3:3.9'
     testImplementation 'org.json:json:20180813'
+    testImplementation 'io.opencensus:opencensus-impl:0.25.0'
 }
 
 task updateVersion(type: Copy) {

--- a/src/main/java/com/google/maps/metrics/OpenCensusMetrics.java
+++ b/src/main/java/com/google/maps/metrics/OpenCensusMetrics.java
@@ -1,0 +1,128 @@
+package com.google.maps.metrics;
+
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Aggregation.Count;
+import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.BucketBoundaries;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewManager;
+import io.opencensus.tags.TagKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/*
+ * OpenCensus metrics which are measured for every request.
+ */
+public final class OpenCensusMetrics {
+  private OpenCensusMetrics() {}
+
+  public static final class Tags {
+    private Tags() {}
+
+    public static final TagKey REQUEST_NAME = TagKey.create("request_name");
+    public static final TagKey HTTP_CODE = TagKey.create("http_code");
+    public static final TagKey API_STATUS = TagKey.create("api_status");
+  }
+
+  public static final class Measures {
+    private Measures() {}
+
+    public static final MeasureLong LATENCY =
+        MeasureLong.create(
+            "maps.googleapis.com/measure/client/latency",
+            "Total time between library method called and results returned",
+            "ms");
+
+    public static final MeasureLong NETWORK_LATENCY =
+        MeasureLong.create(
+            "maps.googleapis.com/measure/client/network_latency",
+            "Network time inside the library",
+            "ms");
+
+    public static final MeasureLong RETRY_COUNT =
+        MeasureLong.create(
+            "maps.googleapis.com/measure/client/retry_count",
+            "How many times any request was retried",
+            "1");
+  }
+
+  private static final class Aggregations {
+    private Aggregations() {}
+
+    private static final Aggregation COUNT = Count.create();
+
+    private static final Aggregation DISTRIBUTION_INTEGERS_10 =
+        Distribution.create(
+            BucketBoundaries.create(
+                Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)));
+
+    // every bucket is ~25% bigger = 20 * 2^(N/3)
+    private static final Aggregation DISTRIBUTION_LATENCY =
+        Distribution.create(
+            BucketBoundaries.create(
+                Arrays.asList(
+                    0.0, 20.0, 25.2, 31.7, 40.0, 50.4, 63.5, 80.0, 100.8, 127.0, 160.0, 201.6,
+                    254.0, 320.0, 403.2, 508.0, 640.0, 806.3, 1015.9, 1280.0, 1612.7, 2031.9,
+                    2560.0, 3225.4, 4063.7)));
+  }
+
+  public static final class Views {
+    private Views() {}
+
+    private static final List<TagKey> fields =
+        tags(Tags.REQUEST_NAME, Tags.HTTP_CODE, Tags.API_STATUS);
+
+    public static final View REQUEST_COUNT =
+        View.create(
+            View.Name.create("maps.googleapis.com/client/request_count"),
+            "Request counts",
+            Measures.LATENCY,
+            Aggregations.COUNT,
+            fields);
+
+    public static final View REQUEST_LATENCY =
+        View.create(
+            View.Name.create("maps.googleapis.com/client/request_latency"),
+            "Latency in msecs",
+            Measures.LATENCY,
+            Aggregations.DISTRIBUTION_LATENCY,
+            fields);
+
+    public static final View NETWORK_LATENCY =
+        View.create(
+            View.Name.create("maps.googleapis.com/client/network_latency"),
+            "Network latency in msecs (internal)",
+            Measures.NETWORK_LATENCY,
+            Aggregations.DISTRIBUTION_LATENCY,
+            fields);
+
+    public static final View RETRY_COUNT =
+        View.create(
+            View.Name.create("maps.googleapis.com/client/retry_count"),
+            "Retries per request",
+            Measures.RETRY_COUNT,
+            Aggregations.DISTRIBUTION_INTEGERS_10,
+            fields);
+  }
+
+  public static void registerAllViews() {
+    registerAllViews(Stats.getViewManager());
+  }
+
+  public static void registerAllViews(ViewManager viewManager) {
+    View[] views_to_register =
+        new View[] {
+          Views.REQUEST_COUNT, Views.REQUEST_LATENCY, Views.NETWORK_LATENCY, Views.RETRY_COUNT
+        };
+    for (View view : views_to_register) {
+      viewManager.registerView(view);
+    }
+  }
+
+  private static List<TagKey> tags(TagKey... items) {
+    return Collections.unmodifiableList(Arrays.asList(items));
+  }
+}

--- a/src/main/java/com/google/maps/metrics/OpenCensusRequestMetrics.java
+++ b/src/main/java/com/google/maps/metrics/OpenCensusRequestMetrics.java
@@ -1,0 +1,75 @@
+package com.google.maps.metrics;
+
+import io.opencensus.stats.StatsRecorder;
+import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagValue;
+import io.opencensus.tags.Tagger;
+
+/** An OpenCensus logger that generates success and latency metrics. */
+final class OpenCensusRequestMetrics implements RequestMetrics {
+  private final String requestName;
+  private final Tagger tagger;
+  private final StatsRecorder statsRecorder;
+
+  private long requestStart;
+  private long networkStart;
+  private long networkTime;
+  private boolean finished;
+
+  OpenCensusRequestMetrics(String requestName, Tagger tagger, StatsRecorder statsRecorder) {
+    this.requestName = requestName;
+    this.tagger = tagger;
+    this.statsRecorder = statsRecorder;
+    this.requestStart = milliTime();
+    this.networkStart = milliTime();
+    this.networkTime = 0;
+    this.finished = false;
+  }
+
+  @Override
+  public void startNetwork() {
+    this.networkStart = milliTime();
+  }
+
+  @Override
+  public void endNetwork() {
+    this.networkTime += milliTime() - this.networkStart;
+  }
+
+  @Override
+  public void endRequest(Exception exception, int httpStatusCode, long retryCount) {
+    // multiple endRequest are ignored
+    if (this.finished) {
+      return;
+    }
+    this.finished = true;
+    long requestTime = milliTime() - this.requestStart;
+
+    TagContext tagContext =
+        tagger
+            .currentBuilder()
+            .putLocal(OpenCensusMetrics.Tags.REQUEST_NAME, TagValue.create(requestName))
+            .putLocal(
+                OpenCensusMetrics.Tags.HTTP_CODE, TagValue.create(Integer.toString(httpStatusCode)))
+            .putLocal(OpenCensusMetrics.Tags.API_STATUS, TagValue.create(exceptionName(exception)))
+            .build();
+    statsRecorder
+        .newMeasureMap()
+        .put(OpenCensusMetrics.Measures.LATENCY, requestTime)
+        .put(OpenCensusMetrics.Measures.NETWORK_LATENCY, this.networkTime)
+        .put(OpenCensusMetrics.Measures.RETRY_COUNT, retryCount)
+        .record(tagContext);
+  }
+
+  private String exceptionName(Exception exception) {
+    if (exception == null) {
+      return "";
+    } else {
+      return exception.getClass().getName();
+    }
+  }
+
+  private long milliTime() {
+    return System.currentTimeMillis();
+  }
+}

--- a/src/main/java/com/google/maps/metrics/OpenCensusRequestMetricsReporter.java
+++ b/src/main/java/com/google/maps/metrics/OpenCensusRequestMetricsReporter.java
@@ -1,0 +1,19 @@
+package com.google.maps.metrics;
+
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.StatsRecorder;
+import io.opencensus.tags.Tagger;
+import io.opencensus.tags.Tags;
+
+/** An OpenCensus logger that generates success and latency metrics. */
+public final class OpenCensusRequestMetricsReporter implements RequestMetricsReporter {
+  private static final Tagger tagger = Tags.getTagger();
+  private static final StatsRecorder statsRecorder = Stats.getStatsRecorder();
+
+  public OpenCensusRequestMetricsReporter() {}
+
+  @Override
+  public RequestMetrics newRequest(String requestName) {
+    return new OpenCensusRequestMetrics(requestName, tagger, statsRecorder);
+  }
+}

--- a/src/test/java/com/google/maps/metrics/OpenCensusTest.java
+++ b/src/test/java/com/google/maps/metrics/OpenCensusTest.java
@@ -1,0 +1,122 @@
+package com.google.maps;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.maps.internal.ApiConfig;
+import com.google.maps.metrics.OpenCensusMetrics;
+import com.google.maps.metrics.OpenCensusRequestMetricsReporter;
+import com.google.maps.model.GeocodingResult;
+import io.opencensus.stats.AggregationData;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewData;
+import io.opencensus.tags.TagValue;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MediumTests.class)
+public class OpenCensusTest {
+
+  private MockWebServer server;
+  private GeoApiContext context;
+
+  @Before
+  public void Setup() {
+    server = new MockWebServer();
+    context =
+        new GeoApiContext.Builder()
+            .apiKey("AIza...")
+            .requestMetricsReporter(new OpenCensusRequestMetricsReporter())
+            .baseUrlOverride("http://127.0.0.1:" + server.getPort())
+            .build();
+    OpenCensusMetrics.registerAllViews();
+  }
+
+  @After
+  @SuppressWarnings("CatchAndPrintStackTrace")
+  public void Teardown() {
+    try {
+      server.shutdown();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private MockResponse mockResponse(int code, String status, int delayMs) {
+    MockResponse response = new MockResponse();
+    response.setResponseCode(code);
+    if (status != null) {
+      response.setBody("{\"results\" : [{}], \"status\" : \"" + status + "\" }");
+    }
+    response.setBodyDelay(delayMs, TimeUnit.MILLISECONDS);
+    return response;
+  }
+
+  private void sleep(int milliseconds) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(milliseconds);
+    } catch (Exception e) {
+    }
+  }
+
+  private Map.Entry<List<TagValue>, AggregationData> getMetric(String name) {
+    sleep(10);
+    ViewData viewData = Stats.getViewManager().getView(View.Name.create(name));
+    Map<List<TagValue>, AggregationData> values = viewData.getAggregationMap();
+    assertEquals(1, values.size());
+    for (Map.Entry<List<TagValue>, AggregationData> entry : values.entrySet()) {
+      return entry;
+    }
+    return null;
+  }
+
+  @Test
+  public void testSuccess() throws Exception {
+    server.enqueue(mockResponse(500, "OK", 100)); // retry 1
+    server.enqueue(mockResponse(500, "OK", 100)); // retry 2
+    server.enqueue(mockResponse(200, "OK", 300)); // succeed
+
+    GeocodingResult[] result =
+        context.get(new ApiConfig("/path"), GeocodingApi.Response.class, "k", "v").await();
+    assertEquals(1, result.length);
+
+    List<TagValue> tags =
+        Arrays.asList(TagValue.create(""), TagValue.create("200"), TagValue.create("/path"));
+
+    Map.Entry<List<TagValue>, AggregationData> latencyMetric =
+        getMetric("maps.googleapis.com/client/request_latency");
+    assertNotNull(latencyMetric);
+    assertEquals(tags, latencyMetric.getKey());
+    AggregationData.DistributionData latencyDist =
+        (AggregationData.DistributionData) latencyMetric.getValue();
+    assertEquals(1, latencyDist.getCount());
+    assertTrue(latencyDist.getMean() > 500);
+
+    Map.Entry<List<TagValue>, AggregationData> retryMetric =
+        getMetric("maps.googleapis.com/client/retry_count");
+    assertNotNull(retryMetric);
+    assertEquals(tags, retryMetric.getKey());
+    AggregationData.DistributionData retryDist =
+        (AggregationData.DistributionData) retryMetric.getValue();
+    assertEquals(1, retryDist.getCount());
+    assertEquals(2.0, retryDist.getMean(), 0.1);
+
+    Map.Entry<List<TagValue>, AggregationData> countMetric =
+        getMetric("maps.googleapis.com/client/request_count");
+    assertNotNull(countMetric);
+    assertEquals(tags, countMetric.getKey());
+    AggregationData.CountData count = (AggregationData.CountData) countMetric.getValue();
+    assertEquals(1, count.getCount());
+  }
+}


### PR DESCRIPTION
This is an OpenCensus implementation for RequestMetrics added in #664.
By default it OpenCensus will not log to any target destination.

This is providing a useful implementation for #663 🦕