### PR TITLE
build: Use in-memory ascii-armored keys for signing.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,15 +31,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Publish build
-      run: |
-        echo "Creating .gpg key"
-        echo ${{ secrets.SYNCED_GPG_KEY_ARMOR }} > ./release.asc
-        gpg --quiet --output ./release.gpg --dearmor ./release.asc
-
-        echo "Creating build"
-        ./gradlew build publish --warn --stacktrace \
-        -PsonatypeUsername=${{ secrets.SYNCED_SONATYPE_USERNAME }} \
-        -PsonatypePassword=${{ secrets.SYNCED_SONATYPE_PASSWORD }} \
-        -Psigning.keyId=${{ secrets.SYNCED_GPG_KEY_ID }} \
-        -Psigning.password=${{ secrets.SYNCED_GPG_KEY_PASSWORD }} \
-        -Psigning.secretKeyRingFile=./release.gpg
+      run: ./gradlew build publish --warn --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ jacocoTestReport {
 
 publishing {
     publications {
-        MapsJavaUtils(MavenPublication) {
+        maven(MavenPublication) {
             pom {
                 name = 'Java Client for Google Maps Platform Web Services'
                 description = 'Use the Google Maps Platform Web Services in Java! ' +
@@ -176,19 +176,24 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            username = sonatypeUsername
-            password = sonatypePassword
+            username = System.getenv('SYNCED_SONATYPE_USERNAME')
+            password = System.getenv('SYNCED_SONATYPE_PASSWORD')
             clientTimeout = Duration.ofSeconds(120)
         }
     }
 }
 
 nexusStaging {
-    username = sonatypeUsername
-    password = sonatypePassword
+    username System.getenv('SYNCED_SONATYPE_USERNAME')
+    password System.getenv('SYNCED_SONATYPE_PASSWORD')
     packageGroup = "com.google.maps"
 }
 
 signing {
-    sign publishing.publications.MapsJavaUtils
+    useInMemoryPgpKeys(
+        System.getenv('SYNCED_GPG_KEY_ID'),
+        System.getenv('SYNCED_GPG_KEY_ARMOR'),
+        System.getenv('SYNCED_GPG_KEY_PASSWORD')
+    )
+    sign publishing.publications.maven
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 21 20:20:36 EST 2015
+#Fri Apr 24 10:24:47 PDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Using in-memory ascii-armored key for signing when publishing a build. Also bump gradle to 6.3.