### PR TITLE
fix: Added `plus_code` address type to fix `SafeEnumAdapter` warnings

### DIFF
--- a/src/main/java/com/google/maps/model/AddressType.java
+++ b/src/main/java/com/google/maps/model/AddressType.java
@@ -131,6 +131,9 @@ public enum AddressType implements UrlValue {
   /** A postal code prefix as used to address postal mail within the country. */
   POSTAL_CODE_SUFFIX("postal_code_suffix"),
 
+  /* Plus code */
+  PLUS_CODE("plus_code"),
+
   /** A prominent natural feature. */
   NATURAL_FEATURE("natural_feature"),
 

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -70,6 +70,7 @@ public class EnumsTest {
     m.put(AddressType.PREMISE, "premise");
     m.put(AddressType.SUBPREMISE, "subpremise");
     m.put(AddressType.POSTAL_CODE, "postal_code");
+    m.put(AddressType.PLUS_CODE, "plus_code");
     m.put(AddressType.NATURAL_FEATURE, "natural_feature");
     m.put(AddressType.AIRPORT, "airport");
     m.put(AddressType.PARK, "park");


### PR DESCRIPTION
Fixes #700  🦕

Example of warning:
```
Unknown type for enum com.google.maps.model.AddressType: 'plus_code'
```

Example of a query with `plus_code` address type:
https://maps.googleapis.com/maps/api/geocode/json?address=393V%2BP9%20Ten-Bel%2C%20Spain