### PR TITLE
chore(deps): Upgrade Gson 2.8.5 -> 2.8.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ artifacts {
 dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.76'
     api 'com.squareup.okhttp3:okhttp:3.14.4'
-    api 'com.google.code.gson:gson:2.8.5'
+    api 'com.google.code.gson:gson:2.8.6'
     api 'io.opencensus:opencensus-api:0.25.0'
     implementation 'org.slf4j:slf4j-api:1.7.26'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
See https://github.com/google/gson/compare/gson-parent-2.8.5...gson-parent-2.8.6

---

This causes [dependency convergence](https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html) in downstream code since 2.8.5 is a very old version.