### PR TITLE
fix: Fix incorrect secret key for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ on:
       - '*'
   repository_dispatch:
     types: [publish]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -46,5 +47,5 @@ jobs:
         GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
+        SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}


### PR DESCRIPTION
Looks like the secret key was incorrectly named which was likely why publishing 401s. This should fix #695 