### PR TITLE
fix: Escape sonatype password

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,8 @@ jobs:
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         sed -i -e "s,sonatypeUsername=,sonatypeUsername=$SONATYPE_USERNAME,g" gradle.properties
-        sed -i -e "s,sonatypePassword=,sonatypePassword=$SONATYPE_PASSWORD,g" gradle.properties
+        SONATYPE_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_PASSWORD" | sed -e 's/[\/&]/\\&/g')
+        sed -i -e "s,sonatypePassword=,sonatypePassword=$SONATYPE_PASSWORD_ESCAPED,g" gradle.properties
         sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
         sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
         sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties
@@ -47,5 +48,5 @@ jobs:
         GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
-        SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
+        SONATYPE_PASSWORD: '${{ secrets.SYNCED_SONATYPE_PASSWORD }}'
         SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}


### PR DESCRIPTION
Publish workflow was still failing after #716. Escaping the password however fixed #695. 

After these changes, I verified that the publish workflow works now. See: https://github.com/googlemaps/google-maps-services-java/actions/runs/529636053