### PR TITLE
chore: Move version to build.gradle file.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,15 +6,15 @@ plugins:
   - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files:
-            - "./gradle.properties"
-          from: "version=.*"
-          to: "version=${nextRelease.version}"
+            - "./build.gradle"
+          from: "version = .*"
+          to: "version = ${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"
       publishCmd: "./gradlew publish --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:
-        - "./gradle.properties"
+        - "./build.gradle"
   - "@semantic-release/github"
 options:
   debug: true

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ apply plugin: 'com.github.sherter.google-java-format'
 
 group = 'com.google.maps'
 sourceCompatibility = 1.8
+version = '0.18.1'
 
 repositories {
     mavenCentral()
@@ -161,12 +162,6 @@ publishing {
             artifactId project.ext.artifactId
             version version
             from components.java
-        }
-        gpr(MavenPublication) {
-            groupId group
-            artifactId project.ext.artifactId
-            version version
-            from(components.java)
         }
     }
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=0.18.1
-
 # variables required to allow build.gradle to parse,
 # override in ~/.gradle/gradle.properties
 signing.keyId=


### PR DESCRIPTION
Moving version to build.gradle file instead of gradle.properties
