### PR TITLE
fix: Bump okhttp dependency to 4.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,13 @@ artifacts {
 
 dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.76'
-    api 'com.squareup.okhttp3:okhttp:3.14.4'
+    api 'com.squareup.okhttp3:okhttp:4.9.1'
     api 'com.google.code.gson:gson:2.8.6'
     api 'io.opencensus:opencensus-api:0.25.0'
     implementation 'org.slf4j:slf4j-api:1.7.26'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'org.slf4j:slf4j-simple:1.7.26'
     testImplementation 'org.apache.commons:commons-lang3:3.9'


### PR DESCRIPTION
Bump okhttp to 4.9.1 which is the latest version as of writing.

Related: https://publicobject.com/2020/02/25/okhttp-restricted-apis/

Fixes #735 🦕
