### PR TITLE
fix: Downgrade OkHttp 5.0.0-alpha.7 -> 4.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,12 +52,12 @@ artifacts {
 
 dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:2.0.4'
-    api 'com.squareup.okhttp3:okhttp:5.0.0-alpha.7'
+    api 'com.squareup.okhttp3:okhttp:4.10.0'
     api 'com.google.code.gson:gson:2.9.0'
     api 'io.opencensus:opencensus-api:0.31.0'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.7'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'


### PR DESCRIPTION
This change partially reverts the upgrade performed in #829, and is an alternative fix for #816. OkHttp 4.10.0 depends on Kotlin 1.6.20, which is not vulnerable to CVE-2020-29582.

This downgrade also resolves #832.

See:
- https://square.github.io/okhttp/changelogs/changelog_4x/#version-4100
- https://nvd.nist.gov/vuln/detail/CVE-2020-29582