### PR TITLE
fix: Making TimeZoneApi$Response public to be able to instantiate

### DIFF
--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -54,7 +54,7 @@ public class TimeZoneApi {
         "0");
   }
 
-  private static class Response implements ApiResponse<TimeZone> {
+  public static class Response implements ApiResponse<TimeZone> {
     public String status;
     public String errorMessage;
 


### PR DESCRIPTION
Unable to create instance of class com.google.maps.TimeZoneApi$Response. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.

