### PR TITLE
fix: Making TimeZoneApi$Response public to be able to instantiate

### DIFF
--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -54,7 +54,7 @@ public class TimeZoneApi {
         "0");
   }
 
-  private static class Response implements ApiResponse<TimeZone> {
+  public static class Response implements ApiResponse<TimeZone> {
     public String status;
     public String errorMessage;
 

--- a/src/main/java/com/google/maps/TimeZoneApi.java
+++ b/src/main/java/com/google/maps/TimeZoneApi.java
@@ -57,8 +57,7 @@ public class TimeZoneApi {
   public static class Response implements ApiResponse<TimeZone> {
     public String status;
     public String errorMessage;
-
-    private String timeZoneId;
+    public String timeZoneId;
 
     @Override
     public boolean successful() {

--- a/src/test/java/com/google/maps/TimeZoneApiTest.java
+++ b/src/test/java/com/google/maps/TimeZoneApiTest.java
@@ -18,6 +18,7 @@ package com.google.maps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.maps.errors.ZeroResultsException;
@@ -59,7 +60,7 @@ public class TimeZoneApiTest {
     }
   }
 
-  @Test(expected = ZeroResultsException.class)
+  @Test
   public void testNoResult() throws Exception {
     try (LocalTestServerContext sc =
         new LocalTestServerContext("\n{\n   \"status\" : \"ZERO_RESULTS\"\n}\n")) {
@@ -70,7 +71,7 @@ public class TimeZoneApiTest {
 
       try (LocalTestServerContext sc2 =
           new LocalTestServerContext("\n{\n   \"status\" : \"ZERO_RESULTS\"\n}\n")) {
-        TimeZoneApi.getTimeZone(sc2.context, new LatLng(0, 0)).await();
+          assertThrows(ZeroResultsException.class, () -> TimeZoneApi.getTimeZone(sc2.context, new LatLng(0, 0)).await());
       }
     }
   }


### PR DESCRIPTION
Unable to create instance of class com.google.maps.TimeZoneApi$Response. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.

Fix for similar issue reported:
- https://github.com/googlemaps/google-maps-services-java/issues/170
- https://github.com/googlemaps/google-maps-services-java/issues/914