### PR TITLE
fix: Add missing type administrative_area_level_6 and administrative_area_level_7

### DIFF
--- a/src/main/java/com/google/maps/model/AddressComponentType.java
+++ b/src/main/java/com/google/maps/model/AddressComponentType.java
@@ -70,6 +70,18 @@ public enum AddressComponentType {
    */
   ADMINISTRATIVE_AREA_LEVEL_5("administrative_area_level_5"),
 
+  /**
+   * A sixth-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
+   */
+  ADMINISTRATIVE_AREA_LEVEL_6("administrative_area_level_6"),
+
+  /**
+   * A seventh-order civil entity below the country level. This type indicates a minor civil division.
+   * Not all nations exhibit these administrative levels.
+   */
+  ADMINISTRATIVE_AREA_LEVEL_7("administrative_area_level_7"),
+
   /** A commonly-used alternative name for the entity. */
   COLLOQUIAL_AREA("colloquial_area"),
 

--- a/src/test/java/com/google/maps/model/EnumsTest.java
+++ b/src/test/java/com/google/maps/model/EnumsTest.java
@@ -218,6 +218,8 @@ public class EnumsTest {
     m.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3, "administrative_area_level_3");
     m.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_4, "administrative_area_level_4");
     m.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_5, "administrative_area_level_5");
+    m.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_6, "administrative_area_level_6");
+    m.put(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_7, "administrative_area_level_7");
     m.put(AddressComponentType.COLLOQUIAL_AREA, "colloquial_area");
     m.put(AddressComponentType.LOCALITY, "locality");
     m.put(AddressComponentType.WARD, "ward");


### PR DESCRIPTION
This PR adds the missing AddressComponentType `administrative_area_level_6` and `administrative_area_level_7` 

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #985 🦕
