### PR TITLE
fix #906 - secondary opening hours must be an array

### DIFF
--- a/src/main/java/com/google/maps/model/PlaceDetails.java
+++ b/src/main/java/com/google/maps/model/PlaceDetails.java
@@ -235,7 +235,7 @@ public class PlaceDetails implements Serializable {
    * DRIVE_THROUGH, PICKUP, or TAKEOUT) based on the types of the place. This field includes the
    * special_days subfield of all hours, set for dates that have exceptional hours.
    */
-  public OpeningHours secondaryOpeningHours;
+  public OpeningHours[] secondaryOpeningHours;
 
   /** Specifies if the place serves beer. */
   public Boolean servesBeer;

--- a/src/test/java/com/google/maps/issues/Issue906.java
+++ b/src/test/java/com/google/maps/issues/Issue906.java
@@ -1,0 +1,14 @@
+package com.google.maps.issues;
+
+import org.junit.Test;
+
+public class Issue906 {
+
+    @Test
+    public void test() {
+        // /maps/api/place/details/json
+        // https://maps.googleapis.com/maps/api/place/details/json?key=YOUR_API_KEY&placeid=ChIJTSQM7Smze0gR627zU4Cvkn4
+        // The above placeid is expired/not_found sadly and thus cannot be used to test the fix, thus TODO find a place that has the secondary_opening_hours field
+        // The example/test json provided in resources also does not contain a single example with this field
+    }
+}


### PR DESCRIPTION
Fixes #906 

As shown in the rest api docs here https://developers.google.com/maps/documentation/places/web-service/details?hl=de#Place-secondary_opening_hours secondary_opening_hours should be an array and not a object. 

Do not merge this yet, I am waiting/looking for an example json response that contains this field to verify and add a test case. 
