### PR TITLE
Remove unsupported place details scope field mask

### DIFF
--- a/src/main/java/com/google/maps/PlaceDetailsRequest.java
+++ b/src/main/java/com/google/maps/PlaceDetailsRequest.java
@@ -184,8 +184,6 @@ public class PlaceDetailsRequest
     @Deprecated
     REVIEW("review"),
     REVIEWS("reviews"),
-    @Deprecated
-    SCOPE("scope"),
     SERVES_BEER("serves_beer"),
     SERVES_BREAKFAST("serves_breakfast"),
     SERVES_BRUNCH("serves_brunch"),

--- a/src/test/java/com/google/maps/PlacesApiTest.java
+++ b/src/test/java/com/google/maps/PlacesApiTest.java
@@ -118,6 +118,13 @@ public class PlacesApiTest {
   }
 
   @Test
+  public void testPlaceDetailsFieldMasksDoNotIncludeUnsupportedScope() {
+    for (PlaceDetailsRequest.FieldMask fieldMask : PlaceDetailsRequest.FieldMask.values()) {
+      assertFalse("scope".equals(fieldMask.toUrlValue()));
+    }
+  }
+
+  @Test
   public void testAutocompletePredictionStructuredFormatting() throws Exception {
     try (LocalTestServerContext sc =
         new LocalTestServerContext(autocompletePredictionStructuredFormatting)) {


### PR DESCRIPTION
Thank you for opening a Pull Request!

---
Fixed the unsupported Place Details field mask by removing the invalid scope entry from [PlaceDetailsRequest.java](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added a regression test in [PlacesApiTest.java](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to prevent that field mask from reappearing.

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1065  🦕
